### PR TITLE
Remove trailing whitespace from all .java files

### DIFF
--- a/src/dynamics/AxisMap.java
+++ b/src/dynamics/AxisMap.java
@@ -9,7 +9,7 @@ package dynamics;
  * @author CFD
  */
 public class AxisMap extends VectorMap {
-    
+
     Dynamics ap;
     double latitude;
     double longitude;
@@ -17,71 +17,71 @@ public class AxisMap extends VectorMap {
     int bref;
     StateVector axes[] = new StateVector[3];
     int currentVector;
-    
+
     AxisMap() {}
-    
+
     AxisMap( Dynamics a, int refBody, double lat, double lon, double rmul, double scale) {
         this.ap = a;
         bref = refBody;
         latitude = lat;
         longitude = lon;
         setupAxes();
-        
+
         // move axes from centre of refBody out along x axis to surface.
         StateVector o = new StateVector();
         o = new StateVector( rmul * ap.ss.b[bref].r, 0, 0, 0, 0, 0 );
         extendAxes( scale );         // make axes 500 km long
         moveAxes( o );
-        
+
         // transform axes to place origin at required latitude and longitude on refBody
-        transformAroundYaxis( latitude );        
-        transformAroundZaxis( longitude );               
-        
+        transformAroundYaxis( latitude );
+        transformAroundZaxis( longitude );
+
         // axes[0] is now z axis pointing skyward on surface (true)
         // axes[1] is now x axis pointing east (true)
         // axes[2] is now y axis pointing north (true)
-        
+
         swapAxes();
         swapAxes();
-        //  axes[0] is now x axis pointing east 
+        //  axes[0] is now x axis pointing east
         //  axes[1] is now y axis pointing north
         //  axes[2] is now z axis pointing skyward on surface
-        
-        
-        
+
+
+
 //      System.out.println( "required    " + lat + ", " + lon + ", " + rmul );
 //      System.out.println( "axes origin " + axes[0].x + ", " + axes[0].y + ", " + axes[0].z );
 //      System.out.println( "axes Z " + axes[0].vx + ", " + axes[0].vy + ", " + axes[0].vz );
 //      System.out.println( "axes Y " + axes[1].vx + ", " + axes[1].vy + ", " + axes[1].vz );
 //      System.out.println( "axes X " + axes[2].vx + ", " + axes[2].vy + ", " + axes[2].vz );
-        
+
         currentVector = 0;
-        
+
         axes[0].colour = 6;      // red
         axes[1].colour = 7;      // green
         axes[2].colour = 8;      // blue
-        
+
     }
-    
-    void setupAxes() {        
-        // set up XYZ axes 
+
+    void setupAxes() {
+        // set up XYZ axes
         // origin ---> x axis
         axes[0] = new StateVector( 0, 0, 0, 1.0, 0, 0 );
         // y axis
         axes[1] = new StateVector( 0, 0, 0, 0, 1.0, 0 );
         // z axis
-        axes[2] = new StateVector( 0, 0, 0, 0, 0, 1.0 );        
+        axes[2] = new StateVector( 0, 0, 0, 0, 0, 1.0 );
     }
-    
+
     // extend axes longer
     void extendAxes( double mul ) {
         for (int n=0; n<3; n++ ) {
             axes[n].vx = axes[n].vx * mul;
             axes[n].vy = axes[n].vy * mul;
             axes[n].vz = axes[n].vz * mul;
-        }                
+        }
     }
-    
+
     void moveAxes( StateVector s ) {
         for (int n=0; n<3; n++ ) {
             axes[n].x += s.x;
@@ -90,9 +90,9 @@ public class AxisMap extends VectorMap {
             axes[n].vx += s.x;
             axes[n].vy += s.y;
             axes[n].vz += s.z;
-        }        
+        }
     }
- 
+
     // axis0 --> axis1, axis1 --> axis2, axis2 --> axis0,
     void swapAxes() {
         StateVector v = new StateVector();
@@ -100,33 +100,33 @@ public class AxisMap extends VectorMap {
         axes[0] = axes[2];
         axes[2] = axes[1];
         axes[1] = v;
-        
+
     }
-        
+
     void transformAroundXaxis( double angle ) {
         axes[0] = Mathut.transformAroundXaxis( axes[0], angle * Mathut.degreesToRadians );
         axes[1] = Mathut.transformAroundXaxis( axes[1], angle * Mathut.degreesToRadians );
         axes[2] = Mathut.transformAroundXaxis( axes[2], angle * Mathut.degreesToRadians );
     }
-    
+
     void transformAroundYaxis( double angle ) {
         axes[0] = Mathut.transformAroundYaxis( axes[0], angle * Mathut.degreesToRadians );
         axes[1] = Mathut.transformAroundYaxis( axes[1], angle * Mathut.degreesToRadians );
         axes[2] = Mathut.transformAroundYaxis( axes[2], angle * Mathut.degreesToRadians );
     }
-    
+
     void transformAroundZaxis( double angle ) {
         axes[0] = Mathut.transformAroundZaxis( axes[0], angle * Mathut.degreesToRadians );
         axes[1] = Mathut.transformAroundZaxis( axes[1], angle * Mathut.degreesToRadians );
         axes[2] = Mathut.transformAroundZaxis( axes[2], angle * Mathut.degreesToRadians );
     }
-    
+
      int findNvectors() {
          return( 3 );
      }
-     
+
      StateVector readNextVector() {
          return( axes[currentVector++] );
      }
-       
+
 }

--- a/src/dynamics/Body.java
+++ b/src/dynamics/Body.java
@@ -13,18 +13,18 @@ import java.awt.Graphics;
  * @author CFD
  */
 public class Body {
-    
+
 /*
- * Body class refers to individual bodies 
- */    
-    
+ * Body class refers to individual bodies
+ */
+
     static int uniqueNumber = 0;
     int unique;
     int objectType = 1;
     Dynamics ap;
 
     int num;                                                                    // body number
-    String name;                                                                // body name 
+    String name;                                                                // body name
     int status;
     boolean activated;
     boolean inFreeMotion;
@@ -40,22 +40,22 @@ public class Body {
     double damping = 0.00;                                                      // a value of 1.85 gives 53 m/s terminal velocity in sea level air
     double axial[] = new double[12];                                            // planet spin axis data
     double siderealDay;
-    double siderealClock;                                                       // duplicate of ap siderealClock    
+    double siderealClock;                                                       // duplicate of ap siderealClock
     double rotationPeriod;
     double skipRadius;
-    
+
     /* default constructor */
-    public Body(){}    
-    
+    public Body(){}
+
     /* body constructor - MKS units */
     public Body( Dynamics a, int bn, double jd, double x, double y, double z, double vx, double vy, double vz, double bm, double radius, boolean ifm ) {
-        this.unique = uniqueNumber++;  
+        this.unique = uniqueNumber++;
         this.ap = a;
         this.currentState = new StateVector( x, y, z, vx, vy, vz );
         this.num = bn;
         this.m = bm;
         this.r = radius;
-        this.inFreeMotion = ifm;        
+        this.inFreeMotion = ifm;
 
 //      setBodyCharacteristics(  name, x, y, z, vx, vy, vz, m, ifm );
 
@@ -63,11 +63,11 @@ public class Body {
 
         this.status = 3;
         this.activated = true;
-    }    
-    
+    }
+
     /* body constructor - MKS units */
     public Body( Dynamics a, int bn, StateVector v, double bm, double radius, boolean ifm ) {
-        this.unique = uniqueNumber++;  
+        this.unique = uniqueNumber++;
         this.ap = a;
         this.currentState = new StateVector( 0, 0, 0, 0, 0, 0 );
         currentState.copyStateVectors( v );
@@ -75,15 +75,15 @@ public class Body {
         this.num = bn;
         this.m = bm;
         this.r = radius;
-        this.inFreeMotion = ifm;        
+        this.inFreeMotion = ifm;
 
 //      for ( int n=0; n<=2; n++ ) advanced[n] = new StateVector();
         lastState = new StateVector();
 
         this.status = 3;
         this.activated = true;
-    }    
-    
+    }
+
     void setBodyCharacteristics(  String name, double x, double y, double z, double vx, double vy, double vz, double m, boolean ifm ) {
         this.name = name;
         this.m = m;
@@ -95,15 +95,15 @@ public class Body {
         this.currentState.vx = vx;
         this.currentState.vy = vy;
         this.currentState.vz = vz;
-        this.inFreeMotion = ifm;        
+        this.inFreeMotion = ifm;
     }
 
     // centralBody is current planet selected to be viewed
     void paint( Graphics g ) {
         double lx, ly, lz, rpixels;
-        
+
         ap.offGraphics.setPaintMode();
-        ap.offGraphics.setColor( Color.blue  );    
+        ap.offGraphics.setColor( Color.blue  );
         lx = this.currentState.x - ap.ss.b[ ap.centralBody ].currentState.x;    // paint relative to central body
         ly = this.currentState.y - ap.ss.b[ ap.centralBody ].currentState.y;
         lz = this.currentState.z - ap.ss.b[ ap.centralBody ].currentState.z;
@@ -111,13 +111,13 @@ public class Body {
         rpixels = l_t ( this.r );
         if ( rpixels < 2 ) {
             if ( this.num == 11 ) {
-                ap.offGraphics.setColor( Color.red  );    
+                ap.offGraphics.setColor( Color.red  );
      //         System.out.println( "b11 rel XYZ km " + lx/1000.0 + ", " + ly/1000.0 + ", " + lz/1000.0 + " XYpix " + (int)x_t( lx ) + ", " +  (int)y_t( ly ) );
             }
             // draw point
-            ap.offGraphics.drawLine( (int)x_t( lx ), (int)y_t( ly ), (int)x_t( lx ), (int)y_t( ly ) ); 
-//          ap.offGraphics.drawLine( (int)x_t( lx )-1, (int)y_t( ly ), (int)x_t( lx )+1, (int)y_t( ly ) ); 
-//          ap.offGraphics.drawLine( (int)x_t( lx ), (int)y_t( ly )-1, (int)x_t( lx ), (int)y_t( ly )+1 ); 
+            ap.offGraphics.drawLine( (int)x_t( lx ), (int)y_t( ly ), (int)x_t( lx ), (int)y_t( ly ) );
+//          ap.offGraphics.drawLine( (int)x_t( lx )-1, (int)y_t( ly ), (int)x_t( lx )+1, (int)y_t( ly ) );
+//          ap.offGraphics.drawLine( (int)x_t( lx ), (int)y_t( ly )-1, (int)x_t( lx ), (int)y_t( ly )+1 );
         } else {
             // draw circle around centralBody
             int circlePoints = 24;
@@ -127,15 +127,15 @@ public class Body {
             StateVector circlePoint = new StateVector( x0, y0, 0, x0, y0, 0 );
             circlePoint = Mathut.transformAroundZaxis( circlePoint, stepAngle );
             circlePoint.x = x0;
-            circlePoint.y = y0;            
+            circlePoint.y = y0;
 
             for (int n=0; n<circlePoints; n++ ) {
                 ap.offGraphics.drawLine( (int)x_t( circlePoint.x + lx), (int)y_t( circlePoint.y + ly ), (int)x_t( circlePoint.vx + lx ), (int)y_t( circlePoint.vy + ly ) );
-                circlePoint = Mathut.transformAroundZaxis( circlePoint, stepAngle );                
+                circlePoint = Mathut.transformAroundZaxis( circlePoint, stepAngle );
             }
         }
     }
-    
+
     // x transformation to screen coordinates
     int x_t(double x ) {
         return (int) ( ap.screenXYscale * x + ap.screenXoffset);
@@ -150,7 +150,7 @@ public class Body {
     int l_t(double l ) {
         return (int) ( ap.screenXYscale * l);
     }
-    
+
     /**********start Euler Approximation***********************************************************************/
 
     // Reset acceleration to zero
@@ -181,12 +181,12 @@ public class Body {
                     this.currentState.ax = this.currentState.ax + a * x / r;     // x component of accel
                     this.currentState.ay = this.currentState.ay + a * y / r;     // y component of accel
                     this.currentState.az = this.currentState.az + a * z / r;     // z component of accel
-                }                  
+                }
             }
-            
-        }    
+
+        }
     }
-  
+
     // Calculate accelerations due to damping forces proportional to velocity.
     public void add_damping_acceleration() {
       this.currentState.ax = this.currentState.ax - this.currentState.vx * damping / this.m;
@@ -207,11 +207,8 @@ public class Body {
         this.currentState.x = this.currentState.x + this.currentState.vx * t;         // new x
         this.currentState.y = this.currentState.y + this.currentState.vy * t;         // new y
         this.currentState.z = this.currentState.z + this.currentState.vz * t;         // new z
-    }    
+    }
 
-    /********** end Euler Approximation***********************************************************************/       
-    
+    /********** end Euler Approximation***********************************************************************/
+
 }
-
-
-

--- a/src/dynamics/Dynamics.java
+++ b/src/dynamics/Dynamics.java
@@ -41,7 +41,7 @@ public class Dynamics extends java.applet.Applet implements Runnable {
     Process proc;
 //  FoucaultPendulum fp1;
     FallingTower ft1;
-    
+
     double daySecs = 24.0 * 60.0 * 60.0;     // seconds per day
     double elapsedTime = 64800.0 - 197.44;   // elapsed time since simulation start (18hours added to turn Greenwich towards sun on 21 dec 2012)
                                              // correction 0f 198.2 seconds to match Betelgeuse altitude and azimuth (Feb 2015)
@@ -50,7 +50,7 @@ public class Dynamics extends java.applet.Applet implements Runnable {
     double initialJDCT;
     double targetJDCT;
     double finalJDCT;
-    double baseModifiedJDCT = 2400000.5;     // base of Modified Julian Date (add to produce Julian Date) 
+    double baseModifiedJDCT = 2400000.5;     // base of Modified Julian Date (add to produce Julian Date)
     double currentYear = 2012;
     double currentMonth = 12;
     double currentDay = 21;
@@ -59,38 +59,38 @@ public class Dynamics extends java.applet.Applet implements Runnable {
     double siderealClock = 0.0;
     double SiderealDay = 86164.090530833;    // Earth sidereal day duration (seconds)
     int nPlanets;
-    
-    
+
+
     public void init() {
         go = true;
         this.enableEvents( AWTEvent.MOUSE_EVENT_MASK );
-        
-        setSize(400, 400);        
+
+        setSize(400, 400);
         setBackground(Color.white);
 
         appletSize = this.getSize();
         xmax = appletSize.width;         // graphics width
         ymax = appletSize.height;        // graphics height
-               
+
         screenXYscale =    4500.0 * 10.0/1E11;
 //      screenXYscale = 1.0 * 10.0/1E11;
         screenXoffset = xmax / 2.0;
         screenYoffset = ymax / 2.0;
-        
+
 
         offImage = createImage( xmax, ymax );
         offGraphics = offImage.getGraphics();
-        
+
         selectOption();
-        
+
 //      ss = new SolarSystem( this );
         ss = new SolarSystemApollo11( this );
-        tetra = new Tetrahedron( this );        
-        
+        tetra = new Tetrahedron( this );
+
         ss.setAxialRotationParams();
         ss.createMaps();
         ss.setAllSiderealClocks( elapsedTime );
-        
+
     }
 
     public void start() {
@@ -109,14 +109,14 @@ public class Dynamics extends java.applet.Applet implements Runnable {
         }
         else super.processMouseEvent(e);
     }
-    
+
 
     public void run() {
         Thread.currentThread().setPriority(Thread.MIN_PRIORITY);
         Thread myThread = Thread.currentThread();
         while (testThread == myThread) {
             if ( go ) {
-  
+
                 if ( count == 5 ) {
                     ft1 = new FallingTower( this, 4, 32.543618, 44.42408, 1.0, 100000.0 );   // Babylon
                 }
@@ -124,18 +124,18 @@ public class Dynamics extends java.applet.Applet implements Runnable {
                     ft1.moveReferenceFrame();
                     if ( count%100 == 0 ) {
                         if ( option == 4 || option == 10 && ft1.index > 0 ) {
-                            ft1.index--;                        
+                            ft1.index--;
                             ft1.flagUnfixed(ft1.currentState[ ft1.index ]);
                         }
                     }
                 }
-                  
-                ss.moveEuler( dt );     
+
+                ss.moveEuler( dt );
                 tetra.moveEuler( dt );
-                
+
                 currentDate = ( advanceCalendar( dt ) );
                 ss.setAllSiderealClocks( elapsedTime );
-                
+
                 repaint();
                 count++;
             }
@@ -144,36 +144,36 @@ public class Dynamics extends java.applet.Applet implements Runnable {
             } catch (InterruptedException e){ }
         }
     }
-       
+
     public void paint(Graphics g) {
         update(g);
     }
 
     public void update(Graphics g) {
-       
+
         offGraphics.setPaintMode();
         if ( clearScreen ) {
             offGraphics.setColor( Color.white );
             offGraphics.fillRect( 0, 0, xmax, ymax );
         }
-        
-        offGraphics.setColor( Color.black );        
+
+        offGraphics.setColor( Color.black );
 
         if ( option != 10 ) {
-            ss.paint(g);          
+            ss.paint(g);
             tetra.paint(g);
         } else {
             if ( count > 6 ) {
                 ft1.paint(g);
             }
         }
-        
-        offGraphics.setColor( Color.black );        
+
+        offGraphics.setColor( Color.black );
         offGraphics.drawString( currentDate, 5, ymax-10);
-          
+
         g.drawImage( offImage, 0, 0, this );
     }
-    
+
     public void stop() {
         testThread = null;
     }
@@ -188,31 +188,31 @@ public class Dynamics extends java.applet.Applet implements Runnable {
              currentJDCT = baseJDCT;
              advanceTime = jd - baseJDCT;
              advanceCalendar(daySecs * advanceTime);
-             
+
              setDateByJulianDay( currentJDCT );
          }
-    }     
-         
-    // advance calendar using Julian Day 
+    }
+
+    // advance calendar using Julian Day
     String advanceCalendar(double dt) {
         String sdate;
         double secondsInDay = 24 * 60 * 60;
-        
+
         // advance elapsed time and current Julian Date
         elapsedTime += dt;
         currentJDCT += dt / secondsInDay;
 
         // update sidereal clock
-        siderealClock = elapsedTime % SiderealDay;      
+        siderealClock = elapsedTime % SiderealDay;
 
         // get new date and time
         sdate = setDateByJulianDay( currentJDCT );
         sdate += " dt=" + (float) dt + " s";
-        
+
         return( sdate );
-    }    
-                 
-         
+    }
+
+
     String setDateByJulianDay( double julianDay ) {
         double z, w, x, a, b, c, d, e, f;
         double nyear, nmonth, nday, nhour, nminute, nsecond;
@@ -223,14 +223,14 @@ public class Dynamics extends java.applet.Applet implements Runnable {
         double secondsInHour = 60 * 60;
         double secondsInMinute = 60;
         String sdate, dayPrefix, hourPrefix;
- 
+
         int year, month, dayOfMonth;
-// from   http://quasar.as.utexas.edu/BillInfo/JulianDatesG.html        
-//        To convert a Julian Day Number to a Gregorian date, assume that it is for 0 hours, 
-//        Greenwich time (so that it ends in 0.5). Do the following calculations, again dropping 
-//        the fractional part of all multiplicatons and divisions. 
-//        Note: This method will not give dates accurately on the Gregorian Proleptic Calendar, 
-//        i.e., the calendar you get by extending the Gregorian calendar backwards to years earlier 
+// from   http://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
+//        To convert a Julian Day Number to a Gregorian date, assume that it is for 0 hours,
+//        Greenwich time (so that it ends in 0.5). Do the following calculations, again dropping
+//        the fractional part of all multiplicatons and divisions.
+//        Note: This method will not give dates accurately on the Gregorian Proleptic Calendar,
+//        i.e., the calendar you get by extending the Gregorian calendar backwards to years earlier
 //        than 1582. using the Gregorian leap year rules. In particular, the method fails if Y<400.
 //        check 2299160.5 = 1582 October 15        (checked)
 
@@ -250,8 +250,8 @@ public class Dynamics extends java.applet.Applet implements Runnable {
               currentYear = (int)(c-4715 );  // (if Month is January or February) or C-4716 (otherwise)
           } else {
               currentYear = (int)(c-4716);
-          }    
-          
+          }
+
           // Julian days seem to start at noon.
           currentSecond = ( julianDay - (int)julianDay ) * secondsInDay;
           currentSecond -= secondsInDay * 0.5;
@@ -269,10 +269,10 @@ public class Dynamics extends java.applet.Applet implements Runnable {
                      + prefix(nhour) + ":"
                      + prefix(nminute) + ":"
                      + prefix(nsecond);
-          
+
           return( sdate );
     }
-    
+
     // prefix with '0' if necessary
     String prefix(double number) {
         String s;
@@ -287,65 +287,65 @@ public class Dynamics extends java.applet.Applet implements Runnable {
     void selectOption() {
         if ( option == 1 ) {
             // Apollo 11 trajectory
-            centralBody =   4;            
+            centralBody =   4;
             clearScreen = false;
             dt =  16.0;
             screenXYscale =    4500.0 * 10.0/1E11;
         } else if ( option == 2 ) {
             // Sun and planet orbits
-            centralBody =   1;            
+            centralBody =   1;
             clearScreen = false;
             dt = 2048.0;
             screenXYscale =    1.0 * 10.0/1E11;
         } else if ( option == 3 ) {
             // Venus
-            centralBody =   3;            
+            centralBody =   3;
             clearScreen = true;
             dt = 32.0;
-            screenXYscale =    200000.0 * 10.0/1E11;            
+            screenXYscale =    200000.0 * 10.0/1E11;
         } else if ( option == 4 ) {
             // Earth Falling Tower
-            centralBody =   4;            
+            centralBody =   4;
             clearScreen = true;
             dt = 32.0;
-            screenXYscale =    200000.0 * 10.0/1E11;            
+            screenXYscale =    200000.0 * 10.0/1E11;
         } else if ( option == 5 ) {
             // Mars
-            centralBody =   5;            
+            centralBody =   5;
             clearScreen = true;
             dt = 32.0;
-            screenXYscale =    400000.0 * 10.0/1E11;            
+            screenXYscale =    400000.0 * 10.0/1E11;
         } else if ( option == 6 ) {
             // Jupiter
-            centralBody =   6;            
+            centralBody =   6;
             clearScreen = true;
             dt = 32.0;
-            screenXYscale =    20000.0 * 10.0/1E11;            
+            screenXYscale =    20000.0 * 10.0/1E11;
         } else if ( option == 7 ) {
             // Saturn
-            centralBody =   7;            
+            centralBody =   7;
             clearScreen = true;
             dt = 32.0;
-            screenXYscale =    20000.0 * 10.0/1E11;            
+            screenXYscale =    20000.0 * 10.0/1E11;
         } else if ( option == 8 ) {
             // Uranus
-            centralBody =   8;            
+            centralBody =   8;
             clearScreen = true;
             dt = 32.0;
-            screenXYscale =    30000.0 * 10.0/1E11;            
+            screenXYscale =    30000.0 * 10.0/1E11;
         } else if ( option == 9 ) {
             // Neptune
-            centralBody =   9;            
+            centralBody =   9;
             clearScreen = true;
             dt = 32.0;
-            screenXYscale =    30000.0 * 10.0/1E11;            
+            screenXYscale =    30000.0 * 10.0/1E11;
         } else if ( option == 10 ) {
             // Earth Falling Tower surface reference frame view
             // body radii not scaled properly
-            centralBody =   4;            
+            centralBody =   4;
             clearScreen = true;
             dt = 32.0;
-            screenXYscale =    200000.0 * 10.0/1E11;            
+            screenXYscale =    200000.0 * 10.0/1E11;
         } else if ( option == 11 ) {
             // sun
             centralBody =   1;
@@ -353,6 +353,5 @@ public class Dynamics extends java.applet.Applet implements Runnable {
             dt = 512.0;
             screenXYscale =    1000.0 * 10.0/1E11;
         }
-    }    
+    }
 }
-

--- a/src/dynamics/EarthMap.java
+++ b/src/dynamics/EarthMap.java
@@ -9,14 +9,14 @@ package dynamics;
  * @author CFD
  */
 public class EarthMap extends VectorMap {
-    
+
     int nrows;
     int ncols;
     int currentRow;
 //  StateVector vector[] = new StateVector[ 2000 ];
-            
-  
-    double earthMap[][] = { 
+
+
+    double earthMap[][] = {
     // x, y, z, vx, vy, vz (metres from centre)
     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  },
     { -6011328.094664774, -2739520.0433594054, 2339355.522071642, -6011328.094664774, -2739520.0433594054, 2339355.522071642,  },
@@ -1139,26 +1139,26 @@ public class EarthMap extends VectorMap {
     { 1766809.1389728333, 3212884.0310852923, 5210137.242850633, 1779574.299886377, 3202918.2425902137, 5211928.47826663,  },
     { 1779574.299886377, 3202918.2425902137, 5211928.47826663, 1786785.3161598153, 3197337.9514005296, 5212887.556680034,  },
     { 1786785.3161598153, 3197337.9514005296, 5212887.556680034, 1786785.3161598153, 3197337.9514005296, 5212887.556680034,  },
-    };    
-    
+    };
+
      EarthMap() {
         nrows = earthMap.length;
         ncols = earthMap[0].length;
-        
+
 //      System.out.println( "EarthMap " + earthMap[0][0] + " " + earthMap[1][0] + " " + earthMap[2][0] + " "   );
         currentRow = 0;
-     }  
-     
+     }
+
      int findNrows() {
          return( nrows );
      }
-     
+
      StateVector readNextRow() {
          StateVector v = new StateVector();
          v = new StateVector( earthMap[currentRow][0], earthMap[currentRow][1], earthMap[currentRow][2], earthMap[currentRow][3], earthMap[currentRow][4], earthMap[currentRow][5] );
          currentRow++;
          return( v );
      }
-       
-       
+
+
 }

--- a/src/dynamics/FallingTower.java
+++ b/src/dynamics/FallingTower.java
@@ -13,12 +13,12 @@ import java.awt.Graphics;
  * @author CFD
  */
 public class FallingTower {
-    
+
     Dynamics ap;
     ReferenceFrame rf;
     int bref;                   // reference body on which pendulum is sited
     int bnum;                   // body number of pendulum
-    
+
     StateVector currentState[] = new StateVector[50];
     StateVector newState[] = new StateVector[50];
     StateVector barycentricState[] = new StateVector[50];
@@ -28,23 +28,23 @@ public class FallingTower {
     double screenXYscale;
     double screenXoffset;
     double screenYoffset;
-    
+
     // default constructor
     FallingTower() { }
-    
+
     // The original Foucault pendulum was in the Pantheon, Paris, latitude 48.846252, longitude 2.346157
-    // He suspended a 28-kg brass-coated lead bob with a 67-m-long wire from the dome of the Panthéon, Paris. 
+    // He suspended a 28-kg brass-coated lead bob with a 67-m-long wire from the dome of the Panthéon, Paris.
     // The pendulum's swing rotated clockwise approximately 11.3° per hour, making a full circle in approximately 31.8 hours
     FallingTower( Dynamics a, int ref, double lat, double lon, double rmul, double extend ) {
         this.ap = a;
         this.bref = ref;
-        
+
         screenXYscale =  200000.0 * 10.0/1E11;
         screenXoffset = ap.xmax / 2.0;
         screenYoffset = ap.ymax / 2.0;
-        
+
         createStructure( 500000, 500000, 500000 );
-        
+
         rf = new ReferenceFrame( ap, bref, lat, lon, rmul, extend );
 
         makeClone();
@@ -53,28 +53,28 @@ public class FallingTower {
         firstBnum = ap.ss.nbodies;
         for ( int n=0; n<nVectors; n++ ) {
             ap.ss.b[ ap.ss.nbodies ] = new Body( ap, ap.ss.nbodies, barycentricState[n], 28.0, 100000.0, true );
-            ap.ss.nbodies++;            
+            ap.ss.nbodies++;
         }
         lastBnum = ap.ss.nbodies;
         index = nVectors;
-        
+
     }
-    
+
     // restore body positions
     void moveReferenceFrame() {
         int i;
         StateVector[] sv = new StateVector[50];
-        
+
         // clone barycentric state vectors
-        i = firstBnum; 
+        i = firstBnum;
         for ( int n=0; n<nVectors; n++  ) {
             sv[n] = new StateVector();
             sv[n].copyStateVectors( ap.ss.b[i].currentState );
             i++;
-        }        
+        }
         // transform barycentric state vectors back to reference frame state vectors
         newState = rf.transformFromBarycentricXYZ( sv, nVectors );
-        
+
         // copy newState -> currentState for bodies >= bnum
         for ( i=0; i<nVectors; i++ ) {
             if ( currentState[i].flag1 == 1 ) {
@@ -84,23 +84,23 @@ public class FallingTower {
 //                  System.out.println( "body[" + i + "].x = " + newState[i].x );
 //                  newState[i].vx = -newState[i].vx;
                 }
-                currentState[i].copyStateVectors( newState[i] );   
+                currentState[i].copyStateVectors( newState[i] );
                 currentState[i].flag1 = 0;
             }
         }
-        
+
         makeClone();                        // this so as to prevent currentState being changed during transformation
         barycentricState = rf.transformToBarycentricXYZ( clone, nVectors );
         int n = firstBnum;
         for ( int m=0; m<nVectors; m++  ) {
             if ( isFixed( currentState[m] ) ) {
-                ap.ss.b[n].currentState.copyStateVectors( barycentricState[m] ); 
+                ap.ss.b[n].currentState.copyStateVectors( barycentricState[m] );
             }
             n++;
         }
 
     }
-    
+
     // create some sort of structure somewhere on the surface of the earth
     void createStructure( double dx, double dy, double dz ) {
         int n = 0;
@@ -112,12 +112,12 @@ public class FallingTower {
                     currentState[n] = flagFixed( currentState[n] );       // flag fixed
 //                  System.out.println( "structure " + n + ": " + currentState[n].x + ", "  + currentState[n].y + ", "  + currentState[n].z  + " flag1 " + currentState[n].flag1 );
                     n++;
-                }            
-            }            
+                }
+            }
         }
         nVectors = n;
     }
-    
+
     StateVector flagFixed( StateVector v ) {
         v.flag1 = 1;
         return( v );
@@ -127,7 +127,7 @@ public class FallingTower {
         v.flag1 = 0;
         return( v );
     }
-    
+
     boolean isFixed( StateVector v ) {
         boolean fixed = false;
         if ( v.flag1 == 1 ) fixed = true;
@@ -140,20 +140,20 @@ public class FallingTower {
             clone[n] = this.currentState[n].cloneStateVector();
         }
     }
-    
+
     void paint( Graphics g ) {
         int x, y, r;
         ap.offGraphics.setPaintMode();
-        ap.offGraphics.setColor( Color.blue   );    
-        
+        ap.offGraphics.setColor( Color.blue   );
+
         for ( int n=0; n<nVectors; n++ ) {
             x = x_t( currentState[n].x );
             y = y_t( currentState[n].y );
             r = 10;
-            ap.offGraphics.drawOval( x, y, r, r );            
-        }        
-    }    
-    
+            ap.offGraphics.drawOval( x, y, r, r );
+        }
+    }
+
     // x transformation to screen coordinates
     int x_t( double x ) {
         return (int) ( screenXYscale * x + screenXoffset);
@@ -168,7 +168,6 @@ public class FallingTower {
     int l_t( double l ) {
         return (int) ( screenXYscale * l);
     }
-    
-    
-}
 
+
+}

--- a/src/dynamics/Map.java
+++ b/src/dynamics/Map.java
@@ -12,29 +12,29 @@ import java.awt.Graphics;
  * @author CFD
  */
 public class Map extends Body {
- 
+
     Dynamics ap;
     int bnum;
     VectorMap vmap[] = new VectorMap[10];
     double[][] bodyMap = {
         { 1.00, 90.0, 0, 2, },                                                  // N pole
         { 1.00, -90.0, 0, 1, },                                                 // S pole
-        { 1.0000001569609842, 52.0339, -2.4235, 2, },                           
+        { 1.0000001569609842, 52.0339, -2.4235, 2, },
         { 1.0010001569609842, 52.0339, -1.4235, 1, }
     };
-    
+
     final int RMUL = 0;
     final int LAT = 1;
     final int LON = 2;
     final int PEN = 3;
-    
+
     Map() { }
-    
+
     Map( Dynamics a, int num, double r ) {
         this.ap = a;
         this.bnum = num;
-//      System.out.println( "bnum " + this.bnum );        
-        
+//      System.out.println( "bnum " + this.bnum );
+
         vmap[1] = new VectorMap( this.ap, r, 30.0, false, false );              // lat-long grid map
 
         if ( this.bnum == 4 ) {
@@ -43,8 +43,8 @@ public class Map extends Body {
         } else {
             vmap[0] = new VectorMap();
 //          vmap[2] = new VectorMap();
-        }            
-        
+        }
+
     }
 
     void paint( Graphics g ) {
@@ -52,25 +52,25 @@ public class Map extends Body {
         double fractionOfDay;
         StateVector v = new StateVector();
         ap.offGraphics.setPaintMode();
-        ap.offGraphics.setColor( Color.blue );          
-        
+        ap.offGraphics.setColor( Color.blue );
+
         // paint planet map
         if ( vmap[0].mapPresent ) {
-            vmap[0].spinAndTiltVectorMap( ap.ss.b[bnum] );        
+            vmap[0].spinAndTiltVectorMap( ap.ss.b[bnum] );
             vmap[0].paint( g, Color.BLACK );
         }
 /*
         // paint axes  map
         if ( vmap[2].mapPresent ) {
-            vmap[2].spinAndTiltVectorMap( ap.ss.b[bnum] );        
+            vmap[2].spinAndTiltVectorMap( ap.ss.b[bnum] );
             vmap[2].paint( g );
         }
 */
         // paint latitude and longitude grid map
-        vmap[1].spinAndTiltVectorMap( ap.ss.b[bnum] );        
+        vmap[1].spinAndTiltVectorMap( ap.ss.b[bnum] );
         vmap[1].paint( g );
 
-        // paint simple map 
+        // paint simple map
         for ( n=0; n<4; n++ ) {
             v.latitude = bodyMap[n][LAT];
             v.longitude = bodyMap[n][LON];
@@ -78,8 +78,8 @@ public class Map extends Body {
             fractionOfDay = ap.siderealClock / ( ap.SiderealDay ) ;
             v = Mathut.degreesLatLong_to_relativeXYZ( ap.ss.b[bnum], v, fractionOfDay  );
             ap.offGraphics.drawLine( (int)Mathut.x_t( ap, v.x ), (int)Mathut.y_t( ap, v.y ), (int)Mathut.x_t( ap, v.x ), (int)Mathut.y_t( ap, v.y ) );
-        }    
+        }
 
-        
-    }        
+
+    }
 }

--- a/src/dynamics/Mathut.java
+++ b/src/dynamics/Mathut.java
@@ -19,43 +19,43 @@ import javax.imageio.ImageIO;
  * @author CFD
  */
 public class Mathut {
-    
+
 // General purpose static mathematical utilities (e.g. point transformations)
 // Mostly copied from Orbit2014 Body class
 
- 
+
     public static double D2R = Math.PI / 180.0;
     public static double degreesToRadians = D2R;
     public static double radiansToDegrees = 1 / D2R;
     public static double degreesToHours = 1/15.0;
-    
+
     // (June 2013)
     public static double degreesToRadians( double degree ) {
         return( degree * degreesToRadians );
     }
-    
+
     // (June 2013)
     public static double radiansToDegrees( double radians ) {
         return( radians / degreesToRadians );
     }
-    
+
     // correct azimuths in range -90 to + 270
     public static double normaliseAzimuth( double degrees ) {
         if ( degrees < 0 ) degrees += 360.0;
         return( degrees);
     }
-    
+
     // (June 2013)
     public static double normaliseLongitude( double degrees ) {
         if ( degrees < -180.0 ) {
             degrees = 360.0 + degrees;
-        } else if ( degrees > 180.0 ) {    
+        } else if ( degrees > 180.0 ) {
             degrees = degrees - 360.0;
         }
         return( degrees );
     }
-    
-    
+
+
     // https://www.mkyong.com/java/how-to-write-an-image-to-file-imageio/
     // http://www.java2s.com/Tutorial/Java/0261__2D-Graphics/CreatingaBufferedImagefromanImageobject.htm
     public static void saveImage( Image img, String name, Dynamics thisApplet ) {
@@ -64,7 +64,7 @@ public class Mathut {
         g.drawImage( img, 0, 0, thisApplet );
 //      g.drawImage( img, null, null );
 //      waitForImage(bufferedImage);
-        
+
         try {
             // \ is an escape character, so \\ is equivalent to \
             ImageIO.write( bufferedImage, "jpg", new File("C:\\images\\" + name + ".jpg"));
@@ -75,27 +75,27 @@ public class Mathut {
         	e.printStackTrace();
         }
         System.out.println("Image saved to C:\\images\\" + name + ".jpg" );
-    }    
-    
+    }
+
     public static void printDate() {
            System.out.println(  new SimpleDateFormat("MM/dd/yyyy HH:mm:ss").format(new Date()));
-    }          
-    
+    }
+
     // return index of smallest number of two
     public static int indexOfSmallest( double a, int ia, double b, int ib ) {
         int indexOfSmallest = ia;
         if ( Math.abs(b) < Math.abs(a) ) indexOfSmallest = ib;
         return( indexOfSmallest );
     }
-    
+
     // return index ia or ib of largest number of two numbers a and b
     public static int indexOfLargest( double a, int ia, double b, int ib ) {
         int indexOfLargest = ia;
         if ( Math.abs(b) > Math.abs(a) ) indexOfLargest = ib;
         return( indexOfLargest );
-    }       
-    
-    
+    }
+
+
     // find distance between a body and a statevector
     public static double distanceBetween( Body b1, StateVector s ) {
         double lx = b1.currentState.x - s.x;
@@ -106,7 +106,7 @@ public class Mathut {
         return (ld);
     }
 
-        // using barycentricXYZ, move StateVector s to be on surface of body b1 
+        // using barycentricXYZ, move StateVector s to be on surface of body b1
     public static StateVector makeRadiallyDistant( StateVector b1State, double b1Radius, StateVector s ) {
         double lx = b1State.x - s.x;
         double ly = b1State.y - s.y;
@@ -117,12 +117,12 @@ public class Mathut {
         double correction = b1Radius / ld;
         s.x = correction * Math.abs(lx) + b1State.x;
         s.y = correction * Math.abs(ly) + b1State.y;
-        s.z = correction * Math.abs(lz) + b1State.z;        
-        
+        s.z = correction * Math.abs(lz) + b1State.z;
+
         return( s );
     }
-    
-    
+
+
     // using barycentricXYZ, move StateVector s to be on surface of body b1 (NOT WORKING)
     public static StateVector makeRadiallyDistant( Body b1, StateVector s ) {
         double lx = ( b1.currentState.x - s.x );
@@ -133,18 +133,18 @@ public class Mathut {
         double correction = b1.r / ld;
         s.x = correction * lx + b1.currentState.x;
         s.y = correction * ly + b1.currentState.y;
-        s.z = correction * lz + b1.currentState.z;        
-        
+        s.z = correction * lz + b1.currentState.z;
+
         return( s );
     }
-    
+
        // make sure angle lies between 0 and 2.PI
     public static double normaliseRadianAngle( double a ) {
         double normalisedAngle = a;
         if ( a < 0 ) normalisedAngle = normalisedAngle + 2.0 * Math.PI;
         return( normalisedAngle );
     }
-    
+
     // make sure angle lies between 0 and 360 degrees
     public static double normaliseDegreeAngle( double a ) {
         double normalisedAngle = a;
@@ -165,43 +165,43 @@ public class Mathut {
     // length transformation to screen pixels
     public static int l_t( Dynamics ap, double l ) {
         return (int) ( ap.screenXYscale * l);
-    }    
-    
+    }
+
     // transform a point around the x-axis through xangle (june 2013)
     public static StateVector transformAroundXaxis( StateVector m,  double xangle ) {
         StateVector mt = new StateVector();
         mt.x = m.x;
         mt.y = m.y * Math.cos(xangle) - m.z * Math.sin(xangle);
-        mt.z = m.z * Math.cos(xangle) + m.y * Math.sin(xangle);        
+        mt.z = m.z * Math.cos(xangle) + m.y * Math.sin(xangle);
         mt.vx = m.vx;
         mt.vy = m.vy * Math.cos(xangle) - m.vz * Math.sin(xangle);
-        mt.vz = m.vz * Math.cos(xangle) + m.vy * Math.sin(xangle);        
+        mt.vz = m.vz * Math.cos(xangle) + m.vy * Math.sin(xangle);
         return ( mt );
     }
-    
+
     // transform a point around the y-axis through xangle (june 2013)
     public static StateVector transformAroundYaxis( StateVector m, double xangle ) {
         StateVector mt = new StateVector();
         mt.y = m.y;
         mt.x = m.x * Math.cos(xangle) - m.z * Math.sin(xangle);
-        mt.z = m.z * Math.cos(xangle) + m.x * Math.sin(xangle);        
+        mt.z = m.z * Math.cos(xangle) + m.x * Math.sin(xangle);
         mt.vy = m.vy;
         mt.vx = m.vx * Math.cos(xangle) - m.vz * Math.sin(xangle);
-        mt.vz = m.vz * Math.cos(xangle) + m.vx * Math.sin(xangle);        
+        mt.vz = m.vz * Math.cos(xangle) + m.vx * Math.sin(xangle);
         return ( mt );
     }
-    
+
     // transform a point around the z-axis through xangle (june 2013)
     public static StateVector transformAroundZaxis( StateVector m, double xangle ) {
         StateVector mt = new StateVector();
         mt.z = m.z;
         mt.y = m.y * Math.cos(xangle) + m.x * Math.sin(xangle);
-        mt.x = m.x * Math.cos(xangle) - m.y * Math.sin(xangle);        
+        mt.x = m.x * Math.cos(xangle) - m.y * Math.sin(xangle);
         mt.vz = m.vz;
         mt.vy = m.vy * Math.cos(xangle) + m.vx * Math.sin(xangle);
-        mt.vx = m.vx * Math.cos(xangle) - m.vy * Math.sin(xangle);        
+        mt.vx = m.vx * Math.cos(xangle) - m.vy * Math.sin(xangle);
         return ( mt );
-    }    
+    }
 
     // 06 aug 2016
     public static StateVector tilt( StateVector v, Body b0, double signrotate )  {
@@ -211,27 +211,27 @@ public class Mathut {
         v = Mathut.transformAroundYaxis( v,  -b0.axial[6] * signrotate );
         return( v );
     }
-    
 
-    // find the VX velocity (m/s) of a surface body at longitude = 0 Greenwich meridian, latitude = latitude   
+
+    // find the VX velocity (m/s) of a surface body at longitude = 0 Greenwich meridian, latitude = latitude
     public static double rotationXvelocity( Body b0, double rmul, double latitude ) {
-        double r = b0.r * rmul * Math.cos( latitude ); 
+        double r = b0.r * rmul * Math.cos( latitude );
         double v = r * 2.0 * Math.PI / b0.siderealDay;
         return( v );
     }
-    
+
     // find angle p1-p2-p3 in degrees (fixed aug 2016)
     public static double angleBetween3Points( StateVector vp1, StateVector vp2, StateVector vp3 ) {
         double d, angle = 0;
         StateVector p1 = new StateVector( vp1 );
         StateVector p2 = new StateVector( vp2 );
         StateVector p3 = new StateVector( vp3 );
-        
+
         // set p2 as origin
         p1.subtractStateVector( p2 );
         p3.subtractStateVector( p2 );
-        
-        // transform line p2-p1 onto x axis (and transform p3 at the same time 
+
+        // transform line p2-p1 onto x axis (and transform p3 at the same time
         angle = Math.atan2( p1.z, p1.x );
         p1 = Mathut.transformAroundYaxis( p1, -angle );
         p3 = Mathut.transformAroundYaxis( p3, -angle );
@@ -239,19 +239,19 @@ public class Mathut {
         angle = Math.atan2( p1.y, d );
         p1 = Mathut.transformAroundZaxis( p1, -angle );
         p3 = Mathut.transformAroundZaxis( p3, -angle );
-        
+
         // transform line p2-p3 onto XY plane
         angle = Math.atan2( p3.z, p3.y );
         p3 = Mathut.transformAroundXaxis( p3, -angle );
-        
+
         // find the angle p1-p2-p3
         angle = Mathut.radiansToDegrees( Math.atan2( p3.y, p3.x ) );
-        
+
         return( angle );
     }
 
     // 31 July 2016
-    // returns RA (hrs) in m.longitude, Dec (degrees) in m.latitude 
+    // returns RA (hrs) in m.longitude, Dec (degrees) in m.latitude
     public static StateVector barycentricXYZ_to_RADec( Body b0, StateVector m ) {
         m = Mathut.barycentricXYZ_to_relativeXYZ( b0, m );
         m = Mathut.tilt( m, b0, -1.0 );
@@ -262,21 +262,21 @@ public class Mathut {
         m.longitude = m.longitude / 15.0;                                       // convert degrees to hours
         return( m );
     }
-    
 
-    
+
+
     // right ascension and declination to ecliptic x,y,z (Sep 2013)
     public static StateVector raDec_to_relativeXYZ( double rasc, double decl, double distance ) {
         double lx, ly, lz, ll, lr, x1, y1, z1, xangle;
         double latitude, longitude, fd, vx, vy, vz, v;
-        
+
         // convert ra and dec to longitude and latitude
         latitude = decl;
         longitude = rasc * 15.0;
         if (longitude > 180.0) longitude = longitude - 360.0;
         latitude = latitude * Mathut.degreesToRadians;
         longitude = longitude * Mathut.degreesToRadians;
-                
+
         // find relative lx, ly, lz location from ecliptic 0,0,0
         // using a very long radius
         lr = Math.abs( distance * Math.cos(latitude) );
@@ -285,9 +285,9 @@ public class Mathut {
         lz = lr * Math.tan(latitude);
         ly = lr * Math.sin(longitude);
         lx = lr * Math.cos(longitude);
-        
+
         // vector contains terrestrial x,y,z
-        StateVector m = new StateVector( lx, ly, lz, 0, 0, 0); 
+        StateVector m = new StateVector( lx, ly, lz, 0, 0, 0);
 
         return ( m );
     }
@@ -303,29 +303,29 @@ public class Mathut {
         s.vz += b0.currentState.vz;
         return( s );
     }
-    
+
     public static StateVector degreesLatLong_to_barycentricXYZ( Body b0, StateVector m, double fd  ) {
         StateVector v = new StateVector();
         v = degreesLatLong_to_relativeXYZ( b0, m, fd );
         v = relativeXYZ_to_barycentricXYZ( b0, v );
         return( v );
     }
-    
+
 
     // converts degrees alt-long-radius on body b0 to relativeXYZ
     public static StateVector degreesLatLong_to_relativeXYZ( Body b0, StateVector m, double fd  ) {
 
-        double longitude = ( +m.longitude + fd * 360.0 ) * Mathut.degreesToRadians;   
+        double longitude = ( +m.longitude + fd * 360.0 ) * Mathut.degreesToRadians;
         StateVector v = new StateVector();
 
-        // find x and z locations at y=0 greenwich meridian 
+        // find x and z locations at y=0 greenwich meridian
         v.x  = b0.r * m.length * Math.cos( m.latitude * Mathut.degreesToRadians );
         v.y  = 0;
         v.z  = b0.r * m.length * Math.sin( m.latitude * Mathut.degreesToRadians );
         v.vx = 0;
         v.vy = rotationXvelocity( b0, m.length, m.latitude * Mathut.degreesToRadians );
         v.vz = 0;
-        
+
         // spin round z axis to find x location
         v = Mathut.transformAroundZaxis( v, longitude );
 
@@ -333,10 +333,10 @@ public class Mathut {
         v = Mathut.tilt( v, b0, signrotate );
 
         return( v );
-    }    
-    
+    }
+
     // converts XYZ axes at latitude 0, longitude 0 to lat-long-radius on body b0 to relativeXYZ
-    // axes[0] is origin, axes[1] = x axis pointing Eeast, axes[2] = y axis pointing North, axes[3] = z axis pointing up 
+    // axes[0] is origin, axes[1] = x axis pointing Eeast, axes[2] = y axis pointing North, axes[3] = z axis pointing up
     public static StateVector[] axesLatLong_to_relativeXYZ( Body b0, double lat, double lon, StateVector axes[], double fd  ) {
         int n = 0;
         double signrotate;
@@ -355,8 +355,8 @@ public class Mathut {
         }
 
         return( axes );
-    }    
-    
+    }
+
     public static StateVector barycentricXYZ_to_degreesLatLongRadius( Body b0, StateVector m ) {
         StateVector mcdegrees = new StateVector();
         m = barycentricXYZ_to_latLong( b0, m );
@@ -366,18 +366,18 @@ public class Mathut {
         mcdegrees.length = m.length / b0.r;
         return( mcdegrees );
     }
-    
+
     // Find the  latitude and longitude (measured in radians) of barycentric object m on surface of body b0
     public static StateVector barycentricXYZ_to_latLong( Body b0, StateVector m ) {
         m = barycentricXYZ_to_relativeXYZ( b0, m );
         m = Mathut.tilt( m, b0, -1.0 );
-        
+
         m = relativeXYZ_to_latLong( m );
         double fd = b0.siderealClock / b0.siderealDay;
         m.longitude = ( m.longitude - fd * 2.0 * Math.PI );
         return( m );
     }
-    
+
     // (jan 2015)
     // modified dec 2014 to change 'this.x' to 'v.x'
     public static StateVector barycentricXYZ_to_relativeXYZ( Body b0, StateVector m  ) {
@@ -389,10 +389,10 @@ public class Mathut {
         m.vz -= b0.currentState.vz;
         return( m );
     }
-     
+
    // (jan 2015)
     // returns values in radians
-    public static StateVector relativeXYZ_to_latLong( StateVector m ) {        
+    public static StateVector relativeXYZ_to_latLong( StateVector m ) {
         // find host (usually terrestrial) latitude and longitude
         m.length = Math.sqrt(m.x * m.x + m.y * m.y + m.z * m.z);
         double ll = Math.sqrt(m.x * m.x + m.y * m.y);
@@ -400,7 +400,7 @@ public class Mathut {
         m.longitude = Math.atan2(m.y, m.x);
         return( m );
     }
-    
+
     // rotation around z axis for time of day, and
     // rotation around x and y axis using planet fixed north poles (so no need to find sines and cosines each time)
     public static StateVector staticXYZ_to_relativeXYZ( double rotationAngle, Body b0, StateVector m  ) {
@@ -409,21 +409,21 @@ public class Mathut {
 
         rotm = Mathut.transformAroundZaxis( m, rotationAngle );
         rotm = Mathut.tilt( rotm, b0, signrotate );                           // signrotate was -1.0
-                
+
         return ( rotm );
     }
 
-    
+
     public static double phaseAngle( StateVector s ) {
         double phaseAngle = Math.atan2( s.y, s.x );
         return( phaseAngle );
     }
-    
+
     public static double oblateRadius( double equatorialRadius, double polarRadius, double latitude ) {
         double a, b, theta, fn;
         double rb, lx, ly;
 
-        // m.latitude is actually the "eccentric anomaly" 
+        // m.latitude is actually the "eccentric anomaly"
         // and I'm hoping that since the Earth is nearly spherical, values won't
         // be far off real values.
         a = equatorialRadius;
@@ -435,11 +435,5 @@ public class Mathut {
         rb = Math.sqrt( lx*lx + ly*ly );
 
         return( rb );
-    }     
-    
-    
+    }
 }
-
-
-
-

--- a/src/dynamics/Process.java
+++ b/src/dynamics/Process.java
@@ -16,7 +16,7 @@ import java.util.StringTokenizer;
  * @author Me
  */
 public class Process {
-    
+
 /*
  * A process is any dynamic assemblage of bodies and ties.
  */
@@ -35,29 +35,29 @@ public class Process {
     final static int JDCT = 4;         // polar radius (km)
     final static int X =  5;           // body X location
     final static int Y =  6;           //  ..  Y    ..
-    final static int Z =  7;           //  ..  Z    .. 
+    final static int Z =  7;           //  ..  Z    ..
     final static int VX =  8;          //  ..  X velocity
     final static int VY =  9;          //  ..  Y    ..
     final static int VZ = 10;          //  ..  Z    ..
     final static int IFM = 11;         //  ..  Z    ..
-   
+
     String line = "body, 1, 1.988544E30, 0.0, 0.01, 6.449674202858886E8, -1.1272171548977591E7, -1.57998353676475E7, 0.4682262903784831, 12.46571925965659, -0.11855327579218379, true";
 
     public Process() { }
-    
+
     public Process( Dynamics a ) {
-        this.ap = a;    
+        this.ap = a;
     }
 
     public Process( Dynamics a, String filename ) {
         double jd;
-        
+
         this.ap = a;
         jd = gpCSVreader( filename );
         ap.setCalendar( jd );
-        
-    } 
-    
+
+    }
+
     // Orbit3D csvReader
     // read .csv (comma separated variables) file containing body Keplerian orbital elements
     // (need to set working directory and applet.policy )
@@ -70,9 +70,9 @@ public class Process {
         rowcount = 0;
         StateVector sv = new StateVector();
         startJulianDate = 1E20;
- 
+
         System.out.println( "gpCSVreader" );
-        
+
         try {
             CSVFile = new BufferedReader(new FileReader(file));
             rowcount = 0;
@@ -83,7 +83,7 @@ public class Process {
             }
 
             while (dataRow != null) {
-                
+
                 StringTokenizer st = new StringTokenizer(dataRow, ",");
                 fieldcount = 0;
                 while (st.hasMoreTokens()) {
@@ -107,7 +107,7 @@ public class Process {
                         nbodies++;
                 }
                 rowcount++;
-                
+
                 try {
                     dataRow = CSVFile.readLine(); // Read next line.
                 } catch (IOException e) {
@@ -126,37 +126,37 @@ public class Process {
         }
 
         System.out.println( rowcount + " lines read from " + file );
-        
+
         return( startJulianDate );
     }
-    
-    
- 
+
+
+
     static void printProcess( Dynamics ap, Body b[], Tie t[] ) {
         int nrows = b.length;
-        
+
         for ( int n=0; n<nrows; n++ ) {
             System.out.print( "body, ");
             System.out.print(  b[n].num + ", " + b[n].m + ", " + b[n].r + ", " + b[n].jd   );
             System.out.println(  b[n].num + ", " + b[n].currentState.x + ", " + b[n].currentState.y + ", " + b[n].currentState.z + ", " + b[n].currentState.vx + ", " + b[n].currentState.vy + ", " + b[n].currentState.vz + ", " + b[n].inFreeMotion );
         }
-        
+
         nrows = t.length;
         for ( int n=0; n<nrows; n++ ) {
             System.out.print( "tie, ");
-            System.out.println(  t[n].num + ", " + t[n].b1.num + ", " + t[n].b2.num + ", " + t[n].tie_free_length + ", " + t[n].tie_max_length + ", " + t[n].tie_K );   
+            System.out.println(  t[n].num + ", " + t[n].b1.num + ", " + t[n].b2.num + ", " + t[n].tie_free_length + ", " + t[n].tie_max_length + ", " + t[n].tie_K );
         }
     }
-    
+
     static void readProcess( Dynamics ap, String lines[], Body b[], Tie t[]  ) {
         int n, fieldcount;
         BufferedReader CSVFile;
         String rs[] = new String[400];
-        
+
         for ( n=0; n<lines.length; n++ ) {
-   
+
             while (lines[n]!= null) {
-                
+
                 StringTokenizer st = new StringTokenizer( lines[n], ",");
                 fieldcount = 0;
                 while (st.hasMoreTokens()) {
@@ -164,46 +164,46 @@ public class Process {
                     rs[ fieldcount] = s;
                     fieldcount++;
                 }
-                
+
                 if ( rs[0].equals("body") ) {
                     b[n].num = (int)Double.valueOf(rs[BNUM]).doubleValue();
                     b[n].m = Double.valueOf(rs[MASS]).doubleValue();
                     b[n].r = Double.valueOf(rs[RADIUS]).doubleValue();
-                    b[n].jd = Double.valueOf(rs[JDCT]).doubleValue();                    
-                    b[n].currentState.x = Double.valueOf(rs[X]).doubleValue();          
-                    b[n].currentState.y = Double.valueOf(rs[Y]).doubleValue();          
-                    b[n].currentState.z = Double.valueOf(rs[Z]).doubleValue();      
-                    b[n].currentState.vx = Double.valueOf(rs[VX]).doubleValue();     
-                    b[n].currentState.vy = Double.valueOf(rs[VY]).doubleValue();     
-                    b[n].currentState.vy = Double.valueOf(rs[VZ]).doubleValue();     
+                    b[n].jd = Double.valueOf(rs[JDCT]).doubleValue();
+                    b[n].currentState.x = Double.valueOf(rs[X]).doubleValue();
+                    b[n].currentState.y = Double.valueOf(rs[Y]).doubleValue();
+                    b[n].currentState.z = Double.valueOf(rs[Z]).doubleValue();
+                    b[n].currentState.vx = Double.valueOf(rs[VX]).doubleValue();
+                    b[n].currentState.vy = Double.valueOf(rs[VY]).doubleValue();
+                    b[n].currentState.vy = Double.valueOf(rs[VZ]).doubleValue();
                     b[n].inFreeMotion = true;
                     if ( rs[IFM].equals("false")  ) { b[n].inFreeMotion = false; }
                 } else if ( rs[0].equals("tie") ) {
-                    
+
                 }
-                
+
             }
-        }        
+        }
     }
-    
-    
+
+
     void moveEuler( double dt ) {
         int n, m;
-        
+
 
         for ( n=0; n<nbodies; n++ ) {
             b[n].zero_acceleration();
-        }    
+        }
 
         for ( n=0; n<nbodies; n++ ) {
-            b[n].add_gravitational_acceleration();    
+            b[n].add_gravitational_acceleration();
             b[n].add_damping_acceleration();
-        }    
+        }
 
         for ( n=0; n<nties; n++ ) {
             t[n].add_elastic_accelerations(b);
-        } 
-        
+        }
+
         for ( n=0; n<nbodies; n++ ) {
             if ( b[n].inFreeMotion ) {
                 b[n].new_speed( dt );
@@ -212,29 +212,26 @@ public class Process {
                 b[n].currentState.vy = 0;
                 b[n].currentState.vz = 0;
             }
-        }    
+        }
 
         for ( n=0; n<nbodies; n++ ) {
             b[n].new_position( dt );
-        }        
+        }
 
-    }     
-    
+    }
+
     void paint( Graphics g ) {
         int n;
-        
-        // paint bodies 
+
+        // paint bodies
         for ( n=0; n<nbodies; n++ ) {
             b[n].paint( g );
-        }    
+        }
 
         // paint ties
         for ( n=0; n<nties; n++ ) {
             t[n].paint( g );
-        } 
-    }    
-    
+        }
+    }
+
 }
-
-
-

--- a/src/dynamics/RK4.java
+++ b/src/dynamics/RK4.java
@@ -16,22 +16,22 @@ public class RK4 {
 
 /*
  * RK4 class carries out RK4 motion calculations on all Bodies in Pool using static methods
- 
+
 class RK4{
-    
+
     public static Pool pool;
     public static Body body;            // pool body under consideration
-    
+
     public static void moveRK4( Pool p, double dt ) {
         int m, n;
-        
+
         pool = p;
-        
+
         // don't perform calculations using dt = 0. 19 aug 2016
         if ( dt != 0 ) {
 
             // find straight-line-advanced body locations
-            for (n = 0; n < pool.nbodies; n++) {                
+            for (n = 0; n < pool.nbodies; n++) {
 //              if ( pool.b[n].status == 3 ) {
                     body = pool.b[n];
                     advanceBody(  dt );
@@ -47,21 +47,21 @@ class RK4{
                     pool.state[n] = integrate( pool.state[n], dt );
                 }
             }
-            
+
             // update positions and speeds
             for (n = 0; n < pool.nbodies; n++) {
                 body = pool.b[n];
                 if ( pool.b[n].status >= 2 && pool.b[n].activated && pool.b[n].inFreeMotion ) {
-                    setVectors( pool.b[n], pool.state[n] );    // RK4 
+                    setVectors( pool.b[n], pool.state[n] );    // RK4
                 }
-            }    
+            }
 
-        } 
+        }
     }
- 
-    
-// RK4 code *************************************************************************************************************    
-    
+
+
+// RK4 code *************************************************************************************************************
+
     // copied from http://gafferongames.com/game-physics/integration-basics/
     // derivatives dx, dv are held as vx, ax in a StateVector.
     // y and z derivatives are also calculated, of course.
@@ -71,7 +71,7 @@ class RK4{
          StateVector dummy = new StateVector();
          StateVector derivative_a, derivative_b, derivative_c, derivative_d;
 
-        
+
          derivative_a = evaluate(state, 0.0, dummy, 0  );              // derivative a returns initial velocity and acceleration
          derivative_b = evaluate(state, dt*0.5, derivative_a, 1 );
          derivative_c = evaluate(state, dt*0.5, derivative_b, 1 );
@@ -93,8 +93,8 @@ class RK4{
 
          return( state );
     }
-    
-    
+
+
     // http://gafferongames.com/game-physics/integration-basics/
     // returns derivative dx, dv as vx, ax in StateVector
     public static StateVector evaluate( StateVector initial, double t, StateVector d, int aindex ){
@@ -104,12 +104,12 @@ class RK4{
         state.z = initial.z + d.vz * t;
         state.vx = initial.vx + d.ax * t;
         state.vy = initial.vy + d.ay * t;
-        state.vz = initial.vz + d.az * t;        
+        state.vz = initial.vz + d.az * t;
 
         return( acceleration( state, aindex ) );
     }
-    
-    
+
+
     // RK4 acceleration
     // Finds acceleration on this body due to all other bodies (> than some minimum mass)
     // Returns this body's current position, speed, and acceleration in a StateVector
@@ -119,20 +119,20 @@ class RK4{
         a = 0;
         StateVector acc = new StateVector();
         StateVector s = new StateVector();
-        
+
         acc.copyStateVectors( state );                        // set accelerations to zero
         acc.ax = 0;
         acc.ay = 0;
         acc.az = 0;
-        
+
         for( int n=0; n<pool.nbodies; n++ ) {
             if ( body.activated && body.inFreeMotion && (n != body.num) && (pool.b[n].status == 3) ) {
- 
+
                 x = state.x - pool.b[n].advanced[ai].x;                 // x distance from m
                 y = state.y - pool.b[n].advanced[ai].y;                 // y distance ..   ..
                 z = state.z - pool.b[n].advanced[ai].z;                 // z distance ..   ..
                 r = Math.sqrt(x * x + y * y + z * z);                       // distance   ..   ..
-               
+
                 // only find interactions with massive bodies > 1 kg mass
                 if ( pool.b[n].m > 1.0 )  {
 
@@ -143,16 +143,16 @@ class RK4{
                         acc.ay = acc.ay + a * y / r;                                // y component of accel
                         acc.az = acc.az + a * z / r;                                // z component of accel
                     }
-                }                   
+                }
             }
-        }        
-        
+        }
+
         return( acc );
     }
-    
+
     // set new positions and speeds using RK4 calculations
     public static void setVectors( Body body, StateVector state ) {
-        
+
         body.lastState.copyStateVectors( body.currentState );
         body.currentState.x = state.x;
         body.currentState.y = state.y;
@@ -160,25 +160,25 @@ class RK4{
         body.currentState.vx = state.vx;
         body.currentState.vy = state.vy;
         body.currentState.vz = state.vz;
-         
+
     }
-    
+
     // produce advanced positions 0 s ahead, dt/2 ahead, and dt ahead i
     public static void advanceBody( double t ) {
-        
+
         for ( int i=0; i<=2; i++ ) {
             body.advanced[i].x = body.currentState.x + body.currentState.vx * (double)i * t / 2.0;
             body.advanced[i].y = body.currentState.y + body.currentState.vy * (double)i * t / 2.0;
             body.advanced[i].z = body.currentState.z + body.currentState.vz * (double)i * t / 2.0;
         }
-        
+
     }
-   
-// end RK4 code ***********************************************************************************************************    
-    
+
+// end RK4 code ***********************************************************************************************************
+
 }
 */
 
 
-    
+
 }

--- a/src/dynamics/ReferenceFrame.java
+++ b/src/dynamics/ReferenceFrame.java
@@ -23,10 +23,10 @@ public class ReferenceFrame {
     double latitude;            // latitude (degrees)
     double longitude;           // longitude (degrees)
     double rmul;                // radius multiple (1.0 for surface)
-    
+
     // default constructor
     ReferenceFrame() { }
-    
+
     // reference frame origin and axes held in statevector XYZ
     ReferenceFrame( Dynamics a, StateVector origin, StateVector xAxis, StateVector yAxis, StateVector zAxis ) {
         this.ap = a;
@@ -35,16 +35,16 @@ public class ReferenceFrame {
         referenceFrame[Yaxis] = new StateVector( origin.x, origin.y, origin.z, yAxis.x, yAxis.y, yAxis.z );
         referenceFrame[Zaxis] = new StateVector( origin.x, origin.y, origin.z, zAxis.x, zAxis.y, zAxis.z );
     }
-    
+
     // reference frame on surface of planet b0
     ReferenceFrame( Dynamics a, int bnum, double lat, double lon, double rmul, double extend ) {
         this.ap = a;
         this.bref = bnum;
         this.latitude = lat;
         this.longitude = lon;
-        this.rmul = rmul;        
+        this.rmul = rmul;
     }
-    
+
     // 17 nov 2017
     // v[] contains a set of XYZ body locations within the current reference frame
     // at lat-long-rmul on the surface of a planet, and with the same velocity as
@@ -62,7 +62,7 @@ public class ReferenceFrame {
 //      double axialRadius = rmul * ap.ss.b[this.bref].r * Math.cos( rLat );
         StateVector o = new StateVector( rmul * ap.ss.b[bref].r, 0, 0, 0, 0, 0 );
 //      System.out.println( "rmul " + rmul + " vy "  + (axialRadius * angularVelocity) );
-        
+
         for ( n=0; n<ns; n++ ) {
             // move vector from planet 0,0,0 origin to surface on X axis
             v[n] = addPositionStateVector( v[n], o );
@@ -88,10 +88,10 @@ public class ReferenceFrame {
             v[n] = addPositionStateVector( v[n], ap.ss.b[bref].currentState );
             // v[n] is now a barycentric state vector carrying XYZ. vx, vy, vz
         }
-                
+
         return( v );
     }
-        
+
     // transformFromBarycentricXYZ() is opposite of transformToBarycentricXYZ()
     StateVector[] transformFromBarycentricXYZ( StateVector[] v, int ns ) {
         int n;
@@ -117,8 +117,8 @@ public class ReferenceFrame {
             v[n] = subtractPositionStateVector( v[n], o );
             // v[n] now holds XYZ and vx, vy, vz in rotating reference frame
         }
-        
-        return( v ); 
+
+        return( v );
     }
 
     // move vector v
@@ -154,14 +154,14 @@ public class ReferenceFrame {
         return( v );
     }
 
-    // 
+    //
     StateVector swapAxes( StateVector v ) {
         double temp = v.x;
         v.x = v.z;
-        v.z = v.y;        
-        v.y = temp;        
+        v.z = v.y;
+        v.y = temp;
         return( v );
     }
- 
-    
+
+
 }

--- a/src/dynamics/SolarSystem.java
+++ b/src/dynamics/SolarSystem.java
@@ -11,23 +11,23 @@ import java.awt.*;
  * @author CFD
  */
 public class SolarSystem extends Process {
-    
+
 //  Dynamics ap;
-    
-    double[][] ssbody = { 
-// (0) Barycentre, (1) Sun, (2) Mercury, (3) Venus, (4) Earth, (5) 5Mars, (6) Jupiter, (7) Saturn, (8) Uranus, (9) Neptune, (10) Luna  on date A.D. 2005-Feb-01 00:00:00.0000   
-// State vectors (kg/km/s): bnum, unused, mass, equ radius, polar radius, spin axis RA, spin axis Dec, rotation period, equinox adjust, JDCT (Julian date), x, y, z, vx, vy, vz, (NASA barycentric state vectors 25 April 2016)        
-        { 0, 0, 1.0, 1.0, 1.0, 0, 0, 0, 0, 2453402.500000000, 0, 0, 0, 0, 0, 0, }, 
-        { 1, 0, 1.988544E30, 695500.032, 695500.032, 90, 0, 0, 0, 2453402.500000000, 6.449674202858886E+05, -1.127217154897759E+04, -1.579983536764750E+04,  4.682262903784831E-04,  1.246571925965659E-02, -1.185532757921838E-04, }, 
-        { 2, 0, 3.301255063417226E23, 2440.0, 2440.0, 90, 0, 0, 0, 2453402.500000000, 1.486213953955887E+07, -6.635708505528798E+07, -6.740730134284206E+06,  3.786494218616802E+01,  1.271539606947296E+01, -2.437237098760083E+00, }, 
-        { 3, 0, 4.867634243309893E24, 6051.8, 6051.8, 90, 0, 0, 0, 2453402.500000000, 1.641356471483682E+07, -1.076568267511855E+08, -2.398553057229348E+06,  3.441639485442118E+01,  4.964155860011824E+00, -1.918810867733495E+00, }, 
-        { 4, 0, 5.972465000E24, 6371.01, 6371.01, 90, 0, 86164.090530833, 0, 2453402.500000000,  -9.829121543945661E+07,  1.092627561338944E+08, -1.701017000098526E+04, -2.257216806314086E+01, -2.008176105996227E+01,  1.204392043128166E-03, }, 
-        { 5, 0, 6.417332641995618E23, 3389.9, 3389.9, 90, 0, 0, 0, 2453402.500000000,  -1.202238020070589E+08, -1.944316515253759E+08, -1.120180061675429E+06,  2.148983152751387E+01, -1.070305946423849E+01, -7.525648800168048E-01, }, 
-        { 6, 0, 1.8986457800595672E27, 71492.0, 71492.0, 90, 0, 0, 0, 2453402.500000000,  -8.046376438857579E+08, -1.310800227631731E+08,  1.854828208607547E+07,  1.939471731899542E+00, -1.227959993064404E+01,  7.521753766719819E-03, }, 
-        { 7, 0, 5.6849685143514635600949590702329E26, 58232.0, 58232.0, 90, 0, 0, 0, 2453402.500000000,  -5.609701355551313E+08,  1.233703176435795E+09,  8.586447359350324E+05, -9.309953235005809E+00, -4.021597846108083E+00,  4.408977577691868E-01, }, 
-        { 8, 0, 8.6824683933763012819043797233395E25, 25362.0, 25362.0, 90, 0, 0, 0, 2453402.500000000,   2.750976959152953E+09, -1.199801396431557E+09, -4.010011731303924E+07,  2.672552487415579E+00,  5.924859647738733E+00, -1.278620255266505E-02, }, 
-        { 9, 0, 1.0243763726603912365620370237477E26, 24624.0, 24624.0, 90, 0, 0, 0, 2453402.500000000,   3.180752853262133E+09, -3.180639539596162E+09, -7.804349508290529E+06,  3.806788498204133E+00,  3.874609434499094E+00, -1.674144641864925E-01, }, 
-        { 10, 0, 7.347075E22, 1737.53, 1727.53, 90, 0, 0, 0, 2453402.500000000,   -9.863742604331432E+07,  1.090923285386415E+08, -1.738000310727954E+04, -2.207565004953833E+01, -2.096271183399073E+01, -8.798304982805849E-02, } 
+
+    double[][] ssbody = {
+// (0) Barycentre, (1) Sun, (2) Mercury, (3) Venus, (4) Earth, (5) 5Mars, (6) Jupiter, (7) Saturn, (8) Uranus, (9) Neptune, (10) Luna  on date A.D. 2005-Feb-01 00:00:00.0000
+// State vectors (kg/km/s): bnum, unused, mass, equ radius, polar radius, spin axis RA, spin axis Dec, rotation period, equinox adjust, JDCT (Julian date), x, y, z, vx, vy, vz, (NASA barycentric state vectors 25 April 2016)
+        { 0, 0, 1.0, 1.0, 1.0, 0, 0, 0, 0, 2453402.500000000, 0, 0, 0, 0, 0, 0, },
+        { 1, 0, 1.988544E30, 695500.032, 695500.032, 90, 0, 0, 0, 2453402.500000000, 6.449674202858886E+05, -1.127217154897759E+04, -1.579983536764750E+04,  4.682262903784831E-04,  1.246571925965659E-02, -1.185532757921838E-04, },
+        { 2, 0, 3.301255063417226E23, 2440.0, 2440.0, 90, 0, 0, 0, 2453402.500000000, 1.486213953955887E+07, -6.635708505528798E+07, -6.740730134284206E+06,  3.786494218616802E+01,  1.271539606947296E+01, -2.437237098760083E+00, },
+        { 3, 0, 4.867634243309893E24, 6051.8, 6051.8, 90, 0, 0, 0, 2453402.500000000, 1.641356471483682E+07, -1.076568267511855E+08, -2.398553057229348E+06,  3.441639485442118E+01,  4.964155860011824E+00, -1.918810867733495E+00, },
+        { 4, 0, 5.972465000E24, 6371.01, 6371.01, 90, 0, 86164.090530833, 0, 2453402.500000000,  -9.829121543945661E+07,  1.092627561338944E+08, -1.701017000098526E+04, -2.257216806314086E+01, -2.008176105996227E+01,  1.204392043128166E-03, },
+        { 5, 0, 6.417332641995618E23, 3389.9, 3389.9, 90, 0, 0, 0, 2453402.500000000,  -1.202238020070589E+08, -1.944316515253759E+08, -1.120180061675429E+06,  2.148983152751387E+01, -1.070305946423849E+01, -7.525648800168048E-01, },
+        { 6, 0, 1.8986457800595672E27, 71492.0, 71492.0, 90, 0, 0, 0, 2453402.500000000,  -8.046376438857579E+08, -1.310800227631731E+08,  1.854828208607547E+07,  1.939471731899542E+00, -1.227959993064404E+01,  7.521753766719819E-03, },
+        { 7, 0, 5.6849685143514635600949590702329E26, 58232.0, 58232.0, 90, 0, 0, 0, 2453402.500000000,  -5.609701355551313E+08,  1.233703176435795E+09,  8.586447359350324E+05, -9.309953235005809E+00, -4.021597846108083E+00,  4.408977577691868E-01, },
+        { 8, 0, 8.6824683933763012819043797233395E25, 25362.0, 25362.0, 90, 0, 0, 0, 2453402.500000000,   2.750976959152953E+09, -1.199801396431557E+09, -4.010011731303924E+07,  2.672552487415579E+00,  5.924859647738733E+00, -1.278620255266505E-02, },
+        { 9, 0, 1.0243763726603912365620370237477E26, 24624.0, 24624.0, 90, 0, 0, 0, 2453402.500000000,   3.180752853262133E+09, -3.180639539596162E+09, -7.804349508290529E+06,  3.806788498204133E+00,  3.874609434499094E+00, -1.674144641864925E-01, },
+        { 10, 0, 7.347075E22, 1737.53, 1727.53, 90, 0, 0, 0, 2453402.500000000,   -9.863742604331432E+07,  1.090923285386415E+08, -1.738000310727954E+04, -2.207565004953833E+01, -2.096271183399073E+01, -8.798304982805849E-02, }
     };
     final int BNUM = 0;         // body number ( Sun=1, Mercury=2 ... Luna=10 )
     final int UNUSED = 1;
@@ -41,47 +41,47 @@ public class SolarSystem extends Process {
     final int JDCT = 9;         // Julian Date (days)
     final int X = 10;           // body X location (km)
     final int Y = 11;           //  ..  Y    ..
-    final int Z = 12;           //  ..  Z    .. 
+    final int Z = 12;           //  ..  Z    ..
     final int VX = 13;          //  ..  X velocity (km/sec)
     final int VY = 14;          //  ..  Y    ..
     final int VZ = 15;          //  ..  Z    ..
-    
+
     String bnames[] = { "Sol, Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune, Luna" };
-    
-    double axialRotation[][] = { 
+
+    double axialRotation[][] = {
     //   RA (degrees),  dec,  x,   y,   z,   period, obliquity  source http://nssdc.gsfc.nasa.gov/planetary/planetfact.html
     //  Obliquity figures from https://en.wikipedia.org/wiki/Axial_tilt.
-    //  "obliquity is the angle between the axis of rotation and the direction perpendicular to the orbital plane"    
+    //  "obliquity is the angle between the axis of rotation and the direction perpendicular to the orbital plane"
     //  My calculations of axial tilt only agree with those of Sun and Earth shown below. Others are a few degrees different.
-    //  I suspect that exial tilt of other planets may be measured with respect to their own orbital planes rather than ecliptic plane.  
+    //  I suspect that exial tilt of other planets may be measured with respect to their own orbital planes rather than ecliptic plane.
     //  { 37.9461468,  89.26413805,  0,  0,  0,  100.0, 0 },             // RA dec of Polaris (for test purposes)
         { 0,  0,  0,  0,  0,  0,  0 },                // 0 barycentre
         { 286.130, 63.870, 0, 0, 0, 609.12, 7.25 },   // 1 sun
         { 281.010, 61.414, 0, 0, 0, 1407.6, 0.03 },   // 2 mercury
         {  92.76, -67.16, 0, 0, 0, 5832.6, 2.64 },    // 3 venus +ve pole
-        {    0.0,  90.0,  0, 0, 0, 23.9345, 23.44 },  // 4 earth            
-        { 317.681, 52.887, 0, 0, 0, 24.6229, 25.19 }, // 5 mars             
-        { 268.057, 64.495, 0, 0, 0, 9.9250, 3.13 },   // 6 jupiter          
-        { 40.589, 83.537, 0, 0, 0, 10.656, 26.73 },   // 7 saturn           
-        {  77.311, 15.175, 0, 0, 0, 17.24, 82.23 },   // 8 uranus +ve pole          
-        { 299.36, 43.46, 0, 0, 0, 16.11, 28.32 },     // 9 neptune          
-        {    0.0, 90.0, 0, 0, 0, 660.0,  0 },             // 10 Luna            
+        {    0.0,  90.0,  0, 0, 0, 23.9345, 23.44 },  // 4 earth
+        { 317.681, 52.887, 0, 0, 0, 24.6229, 25.19 }, // 5 mars
+        { 268.057, 64.495, 0, 0, 0, 9.9250, 3.13 },   // 6 jupiter
+        { 40.589, 83.537, 0, 0, 0, 10.656, 26.73 },   // 7 saturn
+        {  77.311, 15.175, 0, 0, 0, 17.24, 82.23 },   // 8 uranus +ve pole
+        { 299.36, 43.46, 0, 0, 0, 16.11, 28.32 },     // 9 neptune
+        {    0.0, 90.0, 0, 0, 0, 660.0,  0 },             // 10 Luna
     };
 
     Map bmap[] = new Map[12];                   // body maps
-    
+
     SolarSystem() { }
 
     // this constructor used to create solar system from ssbody[] array
     SolarSystem( Dynamics a ) {
-        
+
         double jd = 0;
         this.ap = a;
         int nrows = ssbody.length;
         int ncols = ssbody[0].length;
         StateVector s;
-        
-        for ( int n=0; n<nrows; n++ ) {                        
+
+        for ( int n=0; n<nrows; n++ ) {
             jd = ssbody[n][JDCT];
             s = new StateVector( km_m(ssbody[n][X]), km_m(ssbody[n][Y]), km_m(ssbody[n][Z]), km_m(ssbody[n][VX]), km_m(ssbody[n][VY]), km_m(ssbody[n][VZ]) );
             b[n] = new Body( ap, (int)ssbody[n][BNUM], s, ssbody[n][MASS], ssbody[n][ERADIUS]*1000.0, true );
@@ -95,39 +95,39 @@ public class SolarSystem extends Process {
         b[0].inFreeMotion = false;      // fix barycentre
 
         ap.setCalendar( jd );
-    }        
-    
+    }
+
     // this used to read Orbit3D csv file of planet state vectors
     SolarSystem( Dynamics a, String fn ) {
         super( a, fn );
         this.ap = a;
     }
-    
-    
-    void createMaps() {        
+
+
+    void createMaps() {
         // create maps
-        for ( int n=0; n<ap.nPlanets; n++ ) {                        
+        for ( int n=0; n<ap.nPlanets; n++ ) {
             bmap[n] = new Map( ap, n, ssbody[n][ERADIUS]*1000.0 );
-        }        
+        }
     }
-    
-             
+
+
     void moveEuler( double dt ) {
         int n;
-        
-        for ( n=0; n<nbodies; n++ ) {
-            b[n].zero_acceleration();
-        }    
 
         for ( n=0; n<nbodies; n++ ) {
-            b[n].add_gravitational_acceleration();    
+            b[n].zero_acceleration();
+        }
+
+        for ( n=0; n<nbodies; n++ ) {
+            b[n].add_gravitational_acceleration();
             b[n].add_damping_acceleration();
-        }    
+        }
 
         for ( n=0; n<nties; n++ ) {
             t[n].add_elastic_accelerations(b);
-        } 
-        
+        }
+
         for ( n=0; n<nbodies; n++ ) {
             if ( b[n].inFreeMotion ) {
                 b[n].new_speed( dt );
@@ -136,13 +136,13 @@ public class SolarSystem extends Process {
                 b[n].currentState.vy = 0;
                 b[n].currentState.vz = 0;
             }
-        }    
+        }
 
         for ( n=0; n<nbodies; n++ ) {
             b[n].new_position( dt );
-        }        
+        }
     }
-    
+
     void setAllSiderealClocks( double elapsed_time  ) {
         for ( int n=1; n<nbodies; n++ ) {
             b[n].siderealClock = elapsed_time % b[n].siderealDay;
@@ -150,42 +150,42 @@ public class SolarSystem extends Process {
     }
 
 
-  
+
     void paint( Graphics g ) {
         int n;
-                
-        // paint bodies 
+
+        // paint bodies
         for ( n=0; n<nbodies; n++ ) {
             b[n].paint( g );
-        }    
+        }
 
         // paint ties
         for ( n=0; n<nties; n++ ) {
             t[n].paint( g );
-        } 
-        
+        }
+
         this.bmap[ ap.centralBody ].paint( g );
-        
-    }    
-    
+
+    }
+
     double km_m( double v ) {
         return( 1000.0 * v );
     }
-    
+
     void setAxialRotationParams() {
         int n;
         int nmax = nbodies;
         if ( nmax > 10 ) nmax = 10;
-            
+
         // set up Earth axes first
         setAxialRotationParams( 4 );
-        
+
         // then do all other planet axes
-        for ( n=0; n<nmax; n++ ) { 
+        for ( n=0; n<nmax; n++ ) {
             setAxialRotationParams( n );
-        }        
+        }
     }
-    
+
     void setAxialRotationParams( int n ) {
         double ra, dec;
         StateVector v = new StateVector();
@@ -193,7 +193,7 @@ public class SolarSystem extends Process {
         StateVector vz = new StateVector( 0, 0, 1000, 0, 0, 0);
         StateVector vx = new StateVector( 1000, 0, 0, 0, 0, 0);
         StateVector s = new StateVector();
-        
+
 
             b[n].axial[0] = axialRotation[n][0];
             b[n].axial[1] = axialRotation[n][1];
@@ -207,12 +207,12 @@ public class SolarSystem extends Process {
             b[n].axial[2] = v.x;
             b[n].axial[3] = v.y;
             b[n].axial[4] = v.z;
-            
+
             b[n].rotationPeriod = axialRotation[n][5] * 60.0 * 60.0;            // seconds
 
-            s = Mathut.barycentricXYZ_to_RADec( b[4], v ); 
-            
-            // use north or positive pole xyz to find rotation angles from +z axis 
+            s = Mathut.barycentricXYZ_to_RADec( b[4], v );
+
+            // use north or positive pole xyz to find rotation angles from +z axis
             double alpha = Math.atan2( v.y, v.z );                  // north pole y / z
             double h = Math.sqrt( v.y*v.y + v.z*v.z );              // h = sqrt( y*y + z*z )
             double beta = Math.atan2( v.x, h );                     // north pole x / h
@@ -224,10 +224,10 @@ public class SolarSystem extends Process {
             b[n].axial[10] = Math.cos(beta);
 
     }
-    
+
     void setAxialRotationParams( int n, double ra, double dec ) {
         StateVector m = new StateVector();
-        
+
             b[n].axial[0] = ra;
             b[n].axial[1] = dec;
             ra = ra / 15.0;        // convert degrees to hours
@@ -236,8 +236,8 @@ public class SolarSystem extends Process {
             b[n].axial[2] = m.x;                    // barycentric XYZ of planet axial N pole
             b[n].axial[3] = m.y;
             b[n].axial[4] = m.z;
-            
-            // use north pole xyz to find rotation angles from +z axis 
+
+            // use north pole xyz to find rotation angles from +z axis
             double alpha = Math.atan2( m.y, m.z );                  // north pole y / z
             double h = Math.sqrt( m.y*m.y + m.z*m.z );              // h = sqrt( y*y + z*z )
             double beta = Math.atan2( m.x, h );                     // north pole x / h
@@ -248,6 +248,6 @@ public class SolarSystem extends Process {
             b[n].axial[9] = Math.sin(beta);
             b[n].axial[10] = Math.cos(beta);
 
-    }   
-    
+    }
+
 }

--- a/src/dynamics/SolarSystemApollo11.java
+++ b/src/dynamics/SolarSystemApollo11.java
@@ -12,14 +12,14 @@ import java.awt.Graphics;
  * @author CFD
  */
 public class SolarSystemApollo11 extends Process{
-    
+
 //  Dynamics ap;
-  
+
 /*
 Apollo 11 S-IVB
-The Apollo Saturn V SIVB was the third stage of the Saturn V booster. The SIVB consisted of a truncated cone with a bottom diameter of 10.06 m topped by a long cylinder with a diameter of 6.60 m. Total height was 17.80 m. It contained liquid hydrogen and liquid 
-oxygen tanks and a J2 engine. It was launched into Earth orbit attached to the Command, Service, and Lunar Modules (CSM and LM). The SIVB provided the thrust to take the CSM and LM from Earth orbit into a lunar transfer orbit. After achieving trajectory 
-towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 1969 and made a course correction to head for lunar orbit. The SIVB stage was left on a ballistic trajectory to fly by the Moon on 19 July and entered solar orbit.    
+The Apollo Saturn V SIVB was the third stage of the Saturn V booster. The SIVB consisted of a truncated cone with a bottom diameter of 10.06 m topped by a long cylinder with a diameter of 6.60 m. Total height was 17.80 m. It contained liquid hydrogen and liquid
+oxygen tanks and a J2 engine. It was launched into Earth orbit attached to the Command, Service, and Lunar Modules (CSM and LM). The SIVB provided the thrust to take the CSM and LM from Earth orbit into a lunar transfer orbit. After achieving trajectory
+towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 1969 and made a course correction to head for lunar orbit. The SIVB stage was left on a ballistic trajectory to fly by the Moon on 19 July and entered solar orbit.
 
 2440419.194479167, A.D. 1969-Jul-16 16:40:03.0000,  6.343499939926510E+07, -1.383448940239173E+08, -1.693750687410682E+04,  2.085980004925432E+01,  1.835087874228012E+01,  7.745846007922585E-01,  5.076677773007958E+02,  1.521949708044022E+08, -7.986611412721560E+00,
 2440419.215312500, A.D. 1969-Jul-16 17:10:03.0000,  6.347277701361713E+07, -1.383152833021331E+08, -1.601712773867697E+04,  2.131548690069996E+01,  1.524264687605356E+01,  3.473031427163100E-01,  5.076305406144729E+02,  1.521838075266817E+08, -4.963362719238625E+00,
@@ -227,24 +227,24 @@ towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 
 2440423.423645834, A.D. 1969-Jul-20 22:10:03.0000,  7.251429984450825E+07, -1.336079817039608E+08, -3.536764802716672E+04,  2.482110986359691E+01,  1.306644963350430E+01, -1.721928449847949E-01,  5.070768670326780E+02,  1.520178203626657E+08,  3.559420170623815E-01,
 2440423.444479167, A.D. 1969-Jul-20 22:40:03.0000,  7.255897672881037E+07, -1.335844535958712E+08, -3.567744861081988E+04,  2.481986299857991E+01,  1.307589440821130E+01, -1.720302680360657E-01,  5.070790054445525E+02,  1.520184614424178E+08,  3.563632273016638E-01,
 2440423.465312500, A.D. 1969-Jul-20 23:10:03.0000,  7.260365132059403E+07, -1.335609084788355E+08, -3.598695762649179E+04,  2.481856368311656E+01,  1.308534681933093E+01, -1.718688659029937E-01,  5.070811462940945E+02,  1.520191032529641E+08,  3.567559527293203E-01,
-2440423.486145834, A.D. 1969-Jul-20 23:40:03.0000,  7.264832352802618E+07, -1.335373463421331E+08, -3.629617684658617E+04,  2.481721377770476E+01,  1.309480675677054E+01, -1.717085284105089E-01,  5.070832894230895E+02,  1.520197457468734E+08,  3.571211260820177E-01,    
-*/    
-    
-    double[][] ssbody = { 
-// (0) Barycentre, (1) Sun, (2) Mercury, (3) Venus, (4) Earth, (5) 5Mars, (6) Jupiter, (7) Saturn, (8) Uranus, (9) Neptune, (10) Luna, (11) Apollo 11 S-IVB,  on date  A.D. 1969-Jul-16 16:40:03.0000,   
-// State vectors (kg/km/s): bnum, unused, mass, equ radius, polar radius, spin axis RA, spin axis Dec, rotation period, equinox adjust, JDCT (Julian date), x, y, z, vx, vy, vz, (NASA barycentric state vectors 25 April 2016)        
-        { 0, 0, 1.0, 1.0, 1.0, 0, 0, 0, 0, 2453402.500000000, 0, 0, 0, 0, 0, 0, }, 
-        { 1, 0, 1.988544E30, 695500.032, 695500.032, 90, 0, 0, 0, 2440419.194479167,  6.724047683705250E+05,  1.368183371960980E+05, -9.167197307212591E+03, -8.269140890871091E-04,  9.689398471482327E-03, -2.226706834967561E-05, }, 
-        { 2, 0, 3.301255063417226E23, 2440.0, 2440.0, 90, 0, 0, 0, 2440419.194479167,  5.604580585865147E+06,  4.580931634939645E+07,  3.266908795460155E+06, -5.819890896155647E+01,  7.041518066694305E+00,  5.920417974727668E+00, }, 
-        { 3, 0, 4.867634243309893E24, 6051.8, 6051.8, 90, 0, 0, 0, 2440419.194479167,  1.090060479592348E+08, -6.585748083456414E+06, -6.356240636174833E+06,  2.009846475544523E+00,  3.480302257313270E+01,  3.565173922421874E-01, }, 
-        { 4, 0, 5.972465000E24, 6371.01, 6371.01, 90, 0, 86164.090530833, 0, 2440419.194479167,  6.343341206037694E+07, -1.383555353816606E+08, -1.844088716181368E+04,  2.665426533401776E+01,  1.220446608265464E+01,  1.803982871122933E-03, }, 
-        { 5, 0, 6.417332641995618E23, 3389.9, 3389.9, 90, 0, 0, 0, 2440419.194479167,  2.407535146016249E+07, -2.143240193358925E+08, -5.076693799454808E+06,  2.500557126397957E+01,  4.717913359386351E+00, -5.177244329457018E-01, }, 
-        { 6, 0, 1.8986457800595672E27, 71492.0, 71492.0, 90, 0, 0, 0, 2440419.194479167, -8.014819508685250E+08, -1.471850030703883E+08,  1.856795105978628E+07,  2.208387047361322E+00, -1.224168254647869E+01,  9.203335002956337E-04, }, 
-        { 7, 0, 5.6849685143514635600949590702329E26, 58232.0, 58232.0, 90, 0, 0, 0, 2440419.194479167,  1.171909171745146E+09,  7.368582438261852E+08, -5.945552048404571E+07, -5.666934883678226E+00,  8.158044006168787E+00,  8.206541665798017E-02, }, 
-        { 8, 0, 8.6824683933763012819043797233395E25, 25362.0, 25362.0, 90, 0, 0, 0, 2440419.194479167, -2.731823625809680E+09, -1.858544690681215E+08,  3.476510714276076E+07,  4.116629160582377E-01, -7.112252550218088E+00, -3.182262258414470E-02, }, 
-        { 9, 0, 1.0243763726603912365620370237477E26, 24624.0, 24624.0, 90, 0, 0, 0, 2440419.194479167, -2.394403728893961E+09, -3.850110609895716E+09,  1.344396847873490E+08,  4.581475724820936E+00, -2.839643433710780E+00, -4.774491231976929E-02, }, 
-        { 10, 0, 7.347075E22, 1737.53, 1727.53, 90, 0, 0, 0, 2440419.194479167,  6.313672400814780E+07, -1.380826192727806E+08,  2.445887219801545E+03,  2.600904780466872E+01,  1.147458454512634E+01, -6.957265739587015E-02, }, 
-//      { 11, 0, 1000.0, 0.01, 0.01, 90, 0, 0, 0, 2440419.194479167,  6.343499939926510E+07, -1.383448940239173E+08, -1.693750687410682E+04,  2.085980004925432E+01,  1.835087874228012E+01,  7.745846007922585E-01,  5.076677773007958E+02,  1.521949708044022E+08, -7.986611412721560E+00, } 
+2440423.486145834, A.D. 1969-Jul-20 23:40:03.0000,  7.264832352802618E+07, -1.335373463421331E+08, -3.629617684658617E+04,  2.481721377770476E+01,  1.309480675677054E+01, -1.717085284105089E-01,  5.070832894230895E+02,  1.520197457468734E+08,  3.571211260820177E-01,
+*/
+
+    double[][] ssbody = {
+// (0) Barycentre, (1) Sun, (2) Mercury, (3) Venus, (4) Earth, (5) 5Mars, (6) Jupiter, (7) Saturn, (8) Uranus, (9) Neptune, (10) Luna, (11) Apollo 11 S-IVB,  on date  A.D. 1969-Jul-16 16:40:03.0000,
+// State vectors (kg/km/s): bnum, unused, mass, equ radius, polar radius, spin axis RA, spin axis Dec, rotation period, equinox adjust, JDCT (Julian date), x, y, z, vx, vy, vz, (NASA barycentric state vectors 25 April 2016)
+        { 0, 0, 1.0, 1.0, 1.0, 0, 0, 0, 0, 2453402.500000000, 0, 0, 0, 0, 0, 0, },
+        { 1, 0, 1.988544E30, 695500.032, 695500.032, 90, 0, 0, 0, 2440419.194479167,  6.724047683705250E+05,  1.368183371960980E+05, -9.167197307212591E+03, -8.269140890871091E-04,  9.689398471482327E-03, -2.226706834967561E-05, },
+        { 2, 0, 3.301255063417226E23, 2440.0, 2440.0, 90, 0, 0, 0, 2440419.194479167,  5.604580585865147E+06,  4.580931634939645E+07,  3.266908795460155E+06, -5.819890896155647E+01,  7.041518066694305E+00,  5.920417974727668E+00, },
+        { 3, 0, 4.867634243309893E24, 6051.8, 6051.8, 90, 0, 0, 0, 2440419.194479167,  1.090060479592348E+08, -6.585748083456414E+06, -6.356240636174833E+06,  2.009846475544523E+00,  3.480302257313270E+01,  3.565173922421874E-01, },
+        { 4, 0, 5.972465000E24, 6371.01, 6371.01, 90, 0, 86164.090530833, 0, 2440419.194479167,  6.343341206037694E+07, -1.383555353816606E+08, -1.844088716181368E+04,  2.665426533401776E+01,  1.220446608265464E+01,  1.803982871122933E-03, },
+        { 5, 0, 6.417332641995618E23, 3389.9, 3389.9, 90, 0, 0, 0, 2440419.194479167,  2.407535146016249E+07, -2.143240193358925E+08, -5.076693799454808E+06,  2.500557126397957E+01,  4.717913359386351E+00, -5.177244329457018E-01, },
+        { 6, 0, 1.8986457800595672E27, 71492.0, 71492.0, 90, 0, 0, 0, 2440419.194479167, -8.014819508685250E+08, -1.471850030703883E+08,  1.856795105978628E+07,  2.208387047361322E+00, -1.224168254647869E+01,  9.203335002956337E-04, },
+        { 7, 0, 5.6849685143514635600949590702329E26, 58232.0, 58232.0, 90, 0, 0, 0, 2440419.194479167,  1.171909171745146E+09,  7.368582438261852E+08, -5.945552048404571E+07, -5.666934883678226E+00,  8.158044006168787E+00,  8.206541665798017E-02, },
+        { 8, 0, 8.6824683933763012819043797233395E25, 25362.0, 25362.0, 90, 0, 0, 0, 2440419.194479167, -2.731823625809680E+09, -1.858544690681215E+08,  3.476510714276076E+07,  4.116629160582377E-01, -7.112252550218088E+00, -3.182262258414470E-02, },
+        { 9, 0, 1.0243763726603912365620370237477E26, 24624.0, 24624.0, 90, 0, 0, 0, 2440419.194479167, -2.394403728893961E+09, -3.850110609895716E+09,  1.344396847873490E+08,  4.581475724820936E+00, -2.839643433710780E+00, -4.774491231976929E-02, },
+        { 10, 0, 7.347075E22, 1737.53, 1727.53, 90, 0, 0, 0, 2440419.194479167,  6.313672400814780E+07, -1.380826192727806E+08,  2.445887219801545E+03,  2.600904780466872E+01,  1.147458454512634E+01, -6.957265739587015E-02, },
+//      { 11, 0, 1000.0, 0.01, 0.01, 90, 0, 0, 0, 2440419.194479167,  6.343499939926510E+07, -1.383448940239173E+08, -1.693750687410682E+04,  2.085980004925432E+01,  1.835087874228012E+01,  7.745846007922585E-01,  5.076677773007958E+02,  1.521949708044022E+08, -7.986611412721560E+00, }
     };
     final int BNUM = 0;         // body number ( Sun=1, Mercury=2 ... Luna=10 )
     final int UNUSED = 1;
@@ -258,48 +258,48 @@ towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 
     final int JDCT = 9;         // Julian Date (days)
     final int X = 10;           // body X location (km)
     final int Y = 11;           //  ..  Y    ..
-    final int Z = 12;           //  ..  Z    .. 
+    final int Z = 12;           //  ..  Z    ..
     final int VX = 13;          //  ..  X velocity (km/sec)
     final int VY = 14;          //  ..  Y    ..
     final int VZ = 15;          //  ..  Z    ..
-    
+
     String bnames[] = { "Sol, Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune, Luna" };
-    
-    double axialRotation[][] = { 
+
+    double axialRotation[][] = {
     //   RA (degrees),  dec,  x,   y,   z,   period, obliquity  source http://nssdc.gsfc.nasa.gov/planetary/planetfact.html
     //  Obliquity figures from https://en.wikipedia.org/wiki/Axial_tilt.
-    //  "obliquity is the angle between the axis of rotation and the direction perpendicular to the orbital plane"    
+    //  "obliquity is the angle between the axis of rotation and the direction perpendicular to the orbital plane"
     //  My calculations of axial tilt only agree with those of Sun and Earth shown below. Others are a few degrees different.
-    //  I suspect that exial tilt of other planets may be measured with respect to their own orbital planes rather than ecliptic plane.  
+    //  I suspect that exial tilt of other planets may be measured with respect to their own orbital planes rather than ecliptic plane.
     //  { 37.9461468,  89.26413805,  0,  0,  0,  100.0, 0 },             // RA dec of Polaris (for test purposes)
         { 0,  0,  0,  0,  0,  0,  0 },                // 0 barycentre
         { 286.130, 63.870, 0, 0, 0, 609.12, 7.25 },   // 1 sun
         { 281.010, 61.414, 0, 0, 0, 1407.6, 0.03 },   // 2 mercury
         {  92.76, -67.16, 0, 0, 0, 5832.6, 2.64 },    // 3 venus +ve pole
-        {    0.0,  90.0,  0, 0, 0, 23.9345, 23.44 },  // 4 earth            
-        { 317.681, 52.887, 0, 0, 0, 24.6229, 25.19 }, // 5 mars             
-        { 268.057, 64.495, 0, 0, 0, 9.9250, 3.13 },   // 6 jupiter          
-        { 40.589, 83.537, 0, 0, 0, 10.656, 26.73 },   // 7 saturn           
-        {  77.311, 15.175, 0, 0, 0, 17.24, 82.23 },   // 8 uranus +ve pole          
-        { 299.36, 43.46, 0, 0, 0, 16.11, 28.32 },     // 9 neptune          
-        {    0.0, 90.0, 0, 0, 0, 660.0,  0 },         // 10 Luna            
-        {    0.0, 90.0, 0, 0, 0, 0.0,  0 },           // 10 Apollo11 S-IVB            
+        {    0.0,  90.0,  0, 0, 0, 23.9345, 23.44 },  // 4 earth
+        { 317.681, 52.887, 0, 0, 0, 24.6229, 25.19 }, // 5 mars
+        { 268.057, 64.495, 0, 0, 0, 9.9250, 3.13 },   // 6 jupiter
+        { 40.589, 83.537, 0, 0, 0, 10.656, 26.73 },   // 7 saturn
+        {  77.311, 15.175, 0, 0, 0, 17.24, 82.23 },   // 8 uranus +ve pole
+        { 299.36, 43.46, 0, 0, 0, 16.11, 28.32 },     // 9 neptune
+        {    0.0, 90.0, 0, 0, 0, 660.0,  0 },         // 10 Luna
+        {    0.0, 90.0, 0, 0, 0, 0.0,  0 },           // 10 Apollo11 S-IVB
     };
 
     Map bmap[] = new Map[12];                   // body maps
-    
+
     SolarSystemApollo11() { }
 
     // this constructor used to create solar system from ssbody[] array
     SolarSystemApollo11( Dynamics a ) {
-        
+
         double jd = 0;
         this.ap = a;
         int nrows = ssbody.length;
         int ncols = ssbody[0].length;
         StateVector s;
-        
-        for ( int n=0; n<nrows; n++ ) {                        
+
+        for ( int n=0; n<nrows; n++ ) {
             jd = ssbody[n][JDCT];
             s = new StateVector( km_m(ssbody[n][X]), km_m(ssbody[n][Y]), km_m(ssbody[n][Z]), km_m(ssbody[n][VX]), km_m(ssbody[n][VY]), km_m(ssbody[n][VZ]) );
             b[n] = new Body( ap, (int)ssbody[n][BNUM], s, ssbody[n][MASS], ssbody[n][ERADIUS]*1000.0, true );
@@ -313,42 +313,42 @@ towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 
         b[0].inFreeMotion = false;      // fix barycentre
 
         ap.setCalendar( jd );
-        
-        b[nbodies] = new Body( ap, nbodies, 2440419.194479167, 6.343499939926510E+10, -1.383448940239173E+11, -1.693750687410682E+07,  2.085980004925432E+04,  1.835087874228012E+04,  7.745846007922585E+02,  1000.0, 20.0, true );        
+
+        b[nbodies] = new Body( ap, nbodies, 2440419.194479167, 6.343499939926510E+10, -1.383448940239173E+11, -1.693750687410682E+07,  2.085980004925432E+04,  1.835087874228012E+04,  7.745846007922585E+02,  1000.0, 20.0, true );
         nbodies++;
-    }        
-    
+    }
+
     // this used to read Orbit3D csv file of planet state vectors
     SolarSystemApollo11( Dynamics a, String fn ) {
         super( a, fn );
         this.ap = a;
     }
-    
-    
-    void createMaps() {        
+
+
+    void createMaps() {
         // create maps
-        for ( int n=0; n<ap.nPlanets; n++ ) {                        
+        for ( int n=0; n<ap.nPlanets; n++ ) {
             bmap[n] = new Map( ap, n, ssbody[n][ERADIUS]*1000.0 );
-        }        
+        }
     }
-    
-             
+
+
     void moveEuler( double dt ) {
         int n;
-        
-        for ( n=0; n<nbodies; n++ ) {
-            b[n].zero_acceleration();
-        }    
 
         for ( n=0; n<nbodies; n++ ) {
-            b[n].add_gravitational_acceleration();    
+            b[n].zero_acceleration();
+        }
+
+        for ( n=0; n<nbodies; n++ ) {
+            b[n].add_gravitational_acceleration();
             b[n].add_damping_acceleration();
-        }    
+        }
 
         for ( n=0; n<nties; n++ ) {
             t[n].add_elastic_accelerations(b);
-        } 
-        
+        }
+
         for ( n=0; n<nbodies; n++ ) {
             if ( b[n].inFreeMotion ) {
                 b[n].new_speed( dt );
@@ -357,13 +357,13 @@ towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 
                 b[n].currentState.vy = 0;
                 b[n].currentState.vz = 0;
             }
-        }    
+        }
 
         for ( n=0; n<nbodies; n++ ) {
             b[n].new_position( dt );
-        }        
+        }
     }
-    
+
     void setAllSiderealClocks( double elapsed_time  ) {
         for ( int n=1; n<nbodies; n++ ) {
             b[n].siderealClock = elapsed_time % b[n].siderealDay;
@@ -371,42 +371,42 @@ towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 
     }
 
 
-  
+
     void paint( Graphics g ) {
         int n;
-                
-        // paint bodies 
+
+        // paint bodies
         for ( n=0; n<nbodies; n++ ) {
             b[n].paint( g );
-        }    
+        }
 
         // paint ties
         for ( n=0; n<nties; n++ ) {
             t[n].paint( g );
-        } 
-        
+        }
+
         this.bmap[ ap.centralBody ].paint( g );
-        
-    }    
-    
+
+    }
+
     double km_m( double v ) {
         return( 1000.0 * v );
     }
-    
+
     void setAxialRotationParams() {
         int n;
         int nmax = nbodies;
         if ( nmax > 10 ) nmax = 10;
-            
+
         // set up Earth axes first
         setAxialRotationParams( 4 );
-        
+
         // then do all other planet axes
-        for ( n=0; n<nmax; n++ ) { 
+        for ( n=0; n<nmax; n++ ) {
             setAxialRotationParams( n );
-        }        
+        }
     }
-    
+
     void setAxialRotationParams( int n ) {
         double ra, dec;
         StateVector v = new StateVector();
@@ -414,7 +414,7 @@ towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 
         StateVector vz = new StateVector( 0, 0, 1000, 0, 0, 0);
         StateVector vx = new StateVector( 1000, 0, 0, 0, 0, 0);
         StateVector s = new StateVector();
-        
+
 
             b[n].axial[0] = axialRotation[n][0];
             b[n].axial[1] = axialRotation[n][1];
@@ -428,12 +428,12 @@ towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 
             b[n].axial[2] = v.x;
             b[n].axial[3] = v.y;
             b[n].axial[4] = v.z;
-            
+
             b[n].rotationPeriod = axialRotation[n][5] * 60.0 * 60.0;            // seconds
 
-            s = Mathut.barycentricXYZ_to_RADec( b[4], v ); 
-            
-            // use north or positive pole xyz to find rotation angles from +z axis 
+            s = Mathut.barycentricXYZ_to_RADec( b[4], v );
+
+            // use north or positive pole xyz to find rotation angles from +z axis
             double alpha = Math.atan2( v.y, v.z );                  // north pole y / z
             double h = Math.sqrt( v.y*v.y + v.z*v.z );              // h = sqrt( y*y + z*z )
             double beta = Math.atan2( v.x, h );                     // north pole x / h
@@ -445,10 +445,10 @@ towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 
             b[n].axial[10] = Math.cos(beta);
 
     }
-    
+
     void setAxialRotationParams( int n, double ra, double dec ) {
         StateVector m = new StateVector();
-        
+
             b[n].axial[0] = ra;
             b[n].axial[1] = dec;
             ra = ra / 15.0;        // convert degrees to hours
@@ -457,8 +457,8 @@ towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 
             b[n].axial[2] = m.x;                    // barycentric XYZ of planet axial N pole
             b[n].axial[3] = m.y;
             b[n].axial[4] = m.z;
-            
-            // use north pole xyz to find rotation angles from +z axis 
+
+            // use north pole xyz to find rotation angles from +z axis
             double alpha = Math.atan2( m.y, m.z );                  // north pole y / z
             double h = Math.sqrt( m.y*m.y + m.z*m.z );              // h = sqrt( y*y + z*z )
             double beta = Math.atan2( m.x, h );                     // north pole x / h
@@ -469,7 +469,6 @@ towards the Moon, the LM and CSM decoupled from the SIVB at 17:49 UT on 16 July 
             b[n].axial[9] = Math.sin(beta);
             b[n].axial[10] = Math.cos(beta);
 
-    }   
-    
-}
+    }
 
+}

--- a/src/dynamics/StateVector.java
+++ b/src/dynamics/StateVector.java
@@ -10,7 +10,7 @@ package dynamics;
  * @author CFD
  */
 public class StateVector {
-    
+
 /*
 * StateVector class carries body position, speed, acceleration
 */
@@ -18,7 +18,7 @@ public class StateVector {
     double x;              // location
     double y;
     double z;
-    double vx;             // velocity/view 
+    double vx;             // velocity/view
     double vy;
     double vz;
     double ax;             // acceleration/offset
@@ -49,9 +49,9 @@ public class StateVector {
         this.vz = 0;
         this.ax = 0;
         this.ay = 0;
-        this.az = 0;        
+        this.az = 0;
     }
-    
+
     public StateVector( double x1, double y1, double z1, double xx, double yy, double zz ) {
         this.x = x1;
         this.y = y1;
@@ -61,9 +61,9 @@ public class StateVector {
         this.vz = zz;
         this.ax = 0;
         this.ay = 0;
-        this.az = 0;                
+        this.az = 0;
     }
-    
+
     public StateVector( double x1, double y1, double z1, int f1, int f2, int f3 ) {
         this.x = x1;
         this.y = y1;
@@ -72,8 +72,8 @@ public class StateVector {
         flag2 = f2;
         flag3 = f3;
     }
-    
-    
+
+
     public StateVector( StateVector v ) {
         this.setStateVector( v );
     }
@@ -90,9 +90,9 @@ public class StateVector {
     void setStateVector( double x1, double y1, double z1 ) {
         this.x = x1;
         this.y = y1;
-        this.z = z1;        
+        this.z = z1;
     }
-    
+
     void setStateVector( StateVector v ) {
         this.x = v.x;
         this.y = v.y;
@@ -106,14 +106,14 @@ public class StateVector {
         this.xangle = v.xangle;
         this.yangle = v.yangle;
         this.zangle = v.zangle;
-    }    
-    
+    }
+
     void setvStateVector( double x1, double y1, double z1 ) {
         this.vx = x1;
         this.vy = y1;
-        this.vz = z1;        
+        this.vz = z1;
     }
-        
+
     void clearStateVector() {
         this.x = 0;
         this.y = 0;
@@ -125,7 +125,7 @@ public class StateVector {
         this.ay = 0;
         this.az = 0;
     }
-    
+
     void copyStateVectors( StateVector v ) {
         this.x = v.x;
         this.y = v.y;
@@ -139,20 +139,20 @@ public class StateVector {
         this.flag1 = v.flag1;
         this.flag2 = v.flag2;
     }
-    
+
     boolean sameAs( StateVector v ) {
         boolean same = false;
-        if ( ( this.x - v.x ) + ( this.y - v.y ) + ( this.z - v.z ) == 0 ) same = true;  
+        if ( ( this.x - v.x ) + ( this.y - v.y ) + ( this.z - v.z ) == 0 ) same = true;
         return( same );
     }
-    
+
     StateVector offsetStateVector( StateVector v ) {
         this.x += v.x;
         this.y += v.y;
         this.z += v.z;
         return( this );
     }
-    
+
     StateVector addStateVector( StateVector v ) {
         this.x += v.x;
         this.y += v.y;
@@ -162,7 +162,7 @@ public class StateVector {
         this.vz += v.vz;
         return( this );
     }
-    
+
     StateVector subtractStateVector( StateVector v ) {
         this.x -= v.x;
         this.y -= v.y;
@@ -171,23 +171,23 @@ public class StateVector {
         this.vy -= v.vy;
         this.vz -= v.vz;
         return( this );
-    }    
-    
+    }
+
     double findSpeed( ) {
         double v = Math.sqrt( this.vx*this.vx + this.vy*this.vy + this.vz*this.vz );
-        return( v );        
+        return( v );
     }
-    
+
     double findLength() {
         this.length = Math.sqrt( this.x*this.x + this.y*this.y + this.z*this.z );
         return( this.length );
     }
-    
+
     double findXangle() {
         this.xangle = Math.atan2( this.z, this.x );
         return( this.xangle );
     }
-    
+
     StateVector cloneStateVector() {
         StateVector v = new StateVector();
         v.x = this.x;
@@ -198,10 +198,10 @@ public class StateVector {
         v.vz = this.vz;
         return( v );
     }
-    
+
     StateVector[] cloneStateVector( StateVector[] toClone ) {
         int nrows = toClone.length;
-//      int ncols = toClone[0].length;        
+//      int ncols = toClone[0].length;
         StateVector v[] = new StateVector[ nrows ];
         for ( int n=0; n<nrows; n++ ) {
             v[n].x = toClone[n].x;
@@ -215,17 +215,15 @@ public class StateVector {
         }
         return( v );
     }
-    
-     
+
+
     void printStateVector() {
         System.out.println( "state vector " + x + " " + y + " " + z + " ;"  + vx + " " + vy + " " + vz );
     }
-            
+
     void printStateVectorKm() {
         System.out.println( "state vector " + x/1000.0 + " " + y/1000.0 + " " + z/1000.0 + " ;"  + vx/1000.0 + " " + vy/1000.0 + " " + vz/1000.0 + " km s");
     }
-            
-    
+
+
 }
-
-

--- a/src/dynamics/Tetrahedron.java
+++ b/src/dynamics/Tetrahedron.java
@@ -10,9 +10,9 @@ package dynamics;
  */
 public class Tetrahedron extends Process {
 //  Dynamics ap;
-    
+
     Tetrahedron() { }
-    
+
     Tetrahedron( Dynamics a ) {
         this.ap = a;
         double mass = 1.0;
@@ -23,16 +23,16 @@ public class Tetrahedron extends Process {
         b[this.nbodies] = new Body( ap, -this.nbodies, svref, mass, 1.0, true );
         b[this.nbodies].referenceFrame = 0;
         nbodies++;
-       
+
         b[this.nbodies] = new Body( ap, -this.nbodies, sv.addStateVector(svref), mass, 1.0, true );
         b[this.nbodies].referenceFrame = 0;
         nbodies++;
-       
+
         sv.setStateVector( 0, 7, 0, 0, 0, 0 );
         b[this.nbodies] = new Body( ap, -this.nbodies, sv.addStateVector(svref), mass, 1.0, true );
         b[this.nbodies].referenceFrame = 0;
         nbodies++;
-       
+
         sv.setStateVector( 0, 2, 6, 0, 0, 0 );
         b[this.nbodies] = new Body( ap, -this.nbodies, sv.addStateVector(svref), mass, 1.0, true );
         b[this.nbodies].referenceFrame = 0;
@@ -40,13 +40,13 @@ public class Tetrahedron extends Process {
 /*                              leave ties out to prevent breakup of tetrahedron
         int m;
         for ( int n=0; n<nbodies; n++ ) {
-            m = n+1; 
-            if ( m > 3 ) m = 0; 
+            m = n+1;
+            if ( m > 3 ) m = 0;
             this.t[nties] = new Tie( ap, 0, b[n], b[m], 1.5, 2000.0 );
             nties++;
         }
-*/      
-    
+*/
+
     }
-       
+
 }

--- a/src/dynamics/Tie.java
+++ b/src/dynamics/Tie.java
@@ -13,7 +13,7 @@ import java.awt.Graphics;
  * @author CFD
  */
 public class Tie {
-    
+
 
 // elastic ties connect bodies
     static int uniqueNumber = 0;
@@ -27,22 +27,22 @@ public class Tie {
     int num;                        // tied body number
     Body b1;                      // end body 1
     Body b2;                      // end body 2
-    double tie_length;           // tie current length    
+    double tie_length;           // tie current length
     double tie_free_length;      // tie free length
     double tie_max_length;       // tie maximum length
     double tie_K;                // tie spring constant
     double tension;              // tie tension
     double extension;            // tie extension
     boolean paint_it;
-    Color tie_colour;            // tie colour    
+    Color tie_colour;            // tie colour
 
     // explicit default constructor
     public Tie() {  }
 
 
     public Tie( Dynamics a, int n, Body n1, Body n2, double fmax, double k ){
-      this.unique = uniqueNumber++;  
-      this.exists = true;  
+      this.unique = uniqueNumber++;
+      this.exists = true;
       this.snapped = false;
       ap = a;
       this.paint_it = true;
@@ -50,11 +50,11 @@ public class Tie {
       this.b2 = n2;
 
       this.set_tie_length();
-      this.tie_free_length = this.tie_length; 
+      this.tie_free_length = this.tie_length;
       this.tie_max_length = fmax * this.tie_free_length;
 
       this.tie_colour = new Color(  80,  80,  80 );
-      tie_K = k;           
+      tie_K = k;
     }
 
     // break tie
@@ -81,8 +81,8 @@ public class Tie {
 
     // change body at one end of tie
     void changeTieNode( Body oldb, Body newb ) {
-        if ( this.b1 == oldb ) this.b1 = newb; 
-        if ( this.b2 == oldb ) this.b2 = newb; 
+        if ( this.b1 == oldb ) this.b1 = newb;
+        if ( this.b2 == oldb ) this.b2 = newb;
     }
 
     // Calculate accelerations due to tie tension/compression.
@@ -111,21 +111,21 @@ public class Tie {
         this.b2.currentState.az = this.b2.currentState.az - (f * lz)/(r * this.b2.m);    // z component of accel
 
     }
-   
+
     // paint method draws tie as a line.
     // blue in tension, red in compression
     public void paint( Graphics g ) {
         int x, y, z, x1, y1, x2, y2, ci;
 
         ap.offGraphics.setPaintMode();
-        if ( this.tension < 0 ) { 
+        if ( this.tension < 0 ) {
             ap.offGraphics.setColor( Color.blue );
         } else {
             ap.offGraphics.setColor( Color.red );
         }
-        
+
         ap.offGraphics.drawLine( (int)x_t( b1.currentState.x ), (int)y_t( b1.currentState.y ), (int)x_t( b2.currentState.x ), (int)y_t( b2.currentState.y ) );
-        
+
     }
 
     // x transformation to screen coordinates
@@ -142,8 +142,5 @@ public class Tie {
     int l_t(double l ) {
         return (int) ( ap.screenXYscale * l);
     }
-    
+
 }
-
-
-

--- a/src/dynamics/VectorMap.java
+++ b/src/dynamics/VectorMap.java
@@ -14,7 +14,7 @@ import java.awt.Graphics;
 public class VectorMap extends Body {
     Dynamics ap;
     int bnum;
-    
+
     Body body;
     boolean mapPresent = false;
     int mapSize = 2000;
@@ -29,16 +29,16 @@ public class VectorMap extends Body {
     StateVector eyeXYZ;                                     // eye barycentric XYZ
     StateVector earthXYZ;                                   // eye barycentric XYZ
     double horizonDistance;
-    
-    
+
+
     // default constructor
     VectorMap() {
-    }    
+    }
 
     VectorMap( Dynamics a) {
         this.ap = a;
-    }    
-    
+    }
+
     // read in planet vectorMap
     VectorMap( Dynamics a, int bnum ) {
         this.ap = a;
@@ -51,14 +51,14 @@ public class VectorMap extends Body {
             vector[n] = simpleEarthMap.readNextRow();
         }
         vpoints = nrows;
-        
+
         mapPresent = true;
         createFlyVectorMap( );
         setColorPalette();
 
     }
-    
-    // create XYZ axes vectorMap at lat-long-rmul on planet b0 
+
+    // create XYZ axes vectorMap at lat-long-rmul on planet b0
     VectorMap( Dynamics a, int b0, double lat, double lon, double rmul, double scale ) {
         this.ap = a;
         this.bnum = b0;
@@ -70,18 +70,18 @@ public class VectorMap extends Body {
         }
 
         vpoints = nVectors;
-        
+
         mapPresent = true;
         createFlyVectorMap( );
         setColorPalette();
-              
+
     }
 
-    // create a latitude-longitude vector map, maybe including tropics and degree labels 
+    // create a latitude-longitude vector map, maybe including tropics and degree labels
     VectorMap( Dynamics a, double mapRadius, double degreeStep, boolean tropics, boolean textOn ) {
         int i, j, m, n, nsteps, nhalfsteps;
         double x, y, z, vectorStepAngle, vectorHalfStepAngle, latitude, angle;
-        
+
         ap = a;
         sunXYZ = new StateVector(  );
         earthXYZ = new StateVector(  );
@@ -94,11 +94,11 @@ public class VectorMap extends Body {
         vectorHalfStepAngle =  vectorStepAngle * 0.5;
         y = mapRadius * Math.cos( vectorHalfStepAngle );
         z = mapRadius * Math.sin( vectorHalfStepAngle );
-        
+
         i = 0;
         vector[i] = new StateVector( 0, 0, 0, 0, 0, 0 );     // vector[0] is centre of mapped body
         i++;
-        vector[i] = new StateVector( 0, -mapRadius, 0, 0, -y, z );     
+        vector[i] = new StateVector( 0, -mapRadius, 0, 0, -y, z );
         i++;
 
         for ( n=1; n<nhalfsteps; n++ ) {
@@ -107,16 +107,16 @@ public class VectorMap extends Body {
             vector[i].colour = 1;
             i++;
         }
-            
-        for( n=1; n<nsteps; n++ ) {  
+
+        for( n=1; n<nsteps; n++ ) {
             angle = (double)n * vectorStepAngle;
             for ( j=0; j<nhalfsteps; j++ ) {
-                vector[i] = Mathut.transformAroundZaxis( vector[j], angle );        
+                vector[i] = Mathut.transformAroundZaxis( vector[j], angle );
                 vector[i].colour = 1;
                 i++;
-            }   
+            }
         }
-      
+
         StateVector v = new StateVector();
         for ( m=0; m<nsteps; m++ ) {
             if ( m > 0 ) {
@@ -124,7 +124,7 @@ public class VectorMap extends Body {
                 x = mapRadius * Math.cos( latitude ) * Math.sin( vectorStepAngle );
                 y = mapRadius * Math.cos( latitude ) * Math.cos( vectorStepAngle );
                 z = mapRadius * Math.sin( latitude );
-                vector[i] = new StateVector( x, y, z, 0, 0, 0 );        
+                vector[i] = new StateVector( x, y, z, 0, 0, 0 );
                 v = Mathut.transformAroundZaxis( vector[i], vectorHalfStepAngle );
                 vector[i].vx = v.x;
                 vector[i].vy = v.y;
@@ -139,11 +139,11 @@ public class VectorMap extends Body {
             }
         }
         vpoints = i;
-        
+
         createFlyVectorMap( );
         setColorPalette();
     }
-    
+
     void setColorPalette() {
         colorpalette[0] = new Color(255, 255, 255);
         colorpalette[1] = new Color(200, 200, 200);
@@ -156,7 +156,7 @@ public class VectorMap extends Body {
         colorpalette[8] = Color.blue;
         colorpalette[9] = Color.cyan;
     }
-    
+
     // create the set of vectors which will hold the updated map coordinates
     // produced on the fly at runtime.
     void createFlyVectorMap( ) {
@@ -165,16 +165,16 @@ public class VectorMap extends Body {
             flyVector[n].vtype = 1;
         }
     }
-  
+
     // spin and tilt the vector map, and store in flyVector map..
     void spinAndTiltVectorMap( Body b0 ) {
         double rotate, fd;
         int j;
 
         fd = b0.siderealClock / b0.siderealDay;
-        rotate = ( fd * 360.0 ) * Mathut.degreesToRadians;   // map longitude rotation angle (radians)        
-//      ob = b0.obliquity * Mathut.degreesToRadians;         // map obliquity rotation angle (radians) 
-        
+        rotate = ( fd * 360.0 ) * Mathut.degreesToRadians;   // map longitude rotation angle (radians)
+//      ob = b0.obliquity * Mathut.degreesToRadians;         // map obliquity rotation angle (radians)
+
         for (j=0; j<vpoints; j++) {                                                 // was j<vpoints-1 aug 2016
             flyVector[j] = Mathut.staticXYZ_to_relativeXYZ( rotate, b0, vector[j] );
             flyVector[j].colour = vector[j].colour;
@@ -182,28 +182,28 @@ public class VectorMap extends Body {
         }
 
     }
-    
+
     void paint( Graphics g, Color color ) {
 
         ap.offGraphics.setPaintMode();
-        ap.offGraphics.setColor( color );    
-        for (int j=0; j<vpoints; j++) {                                                 
+        ap.offGraphics.setColor( color );
+        for (int j=0; j<vpoints; j++) {
             if ( flyVector[j].z > 0 ) {
                 ap.offGraphics.drawLine( (int)Mathut.x_t( ap, flyVector[j].x ), (int)Mathut.y_t( ap, flyVector[j].y ), (int)Mathut.x_t( ap, flyVector[j].vx ), (int)Mathut.y_t( ap, flyVector[j].vy ) );
-            } 
+            }
         }
-    }    
-    
+    }
+
     void paint( Graphics g ) {
 
         ap.offGraphics.setPaintMode();
-        ap.offGraphics.setColor( Color.lightGray );    
-        for (int j=0; j<vpoints; j++) {                                                 
+        ap.offGraphics.setColor( Color.lightGray );
+        for (int j=0; j<vpoints; j++) {
             if ( flyVector[j].z > 0 ) {
-                if ( flyVector[j].colour > 0 ) ap.offGraphics.setColor( colorpalette[flyVector[j].colour] ); 
+                if ( flyVector[j].colour > 0 ) ap.offGraphics.setColor( colorpalette[flyVector[j].colour] );
                 ap.offGraphics.drawLine( (int)Mathut.x_t( ap, flyVector[j].x ), (int)Mathut.y_t( ap, flyVector[j].y ), (int)Mathut.x_t( ap, flyVector[j].vx ), (int)Mathut.y_t( ap, flyVector[j].vy ) );
-            } 
+            }
         }
-    }    
-    
+    }
+
 }


### PR DESCRIPTION
Removed trailing whitespace from ends of lines and also removed extra trailing newlines from ends of files for the sake of consistency.

TIP: I found that NetBeans has a handy option that will cause it to delete all trailing whitespace upon saving files. It can be found under `Tools -> Options -> Editor -> On Save -> Remove Trailing Whitespace From`. This can be set to either `All Lines` or `Modified Lines Only`.