### PR TITLE
Remove applet.policy file from root directory

### DIFF
--- a/applet.policy
+++ b/applet.policy
@@ -1,3 +1,0 @@
-grant {
-permission java.security.AllPermission;
-};


### PR DESCRIPTION
  - Unnecessary now that project builds an application instead of an applet. Looks like I missed this file in PR #2, where I removed another applet.policy from the src/dynamics/ directory, but missed this one.