### PR TITLE
Fix "bootstrap class path not set in conjunction with -source 1.7" warning

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -36,8 +36,8 @@ javac.deprecation=false
 javac.external.vm=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.7
-javac.target=1.7
+javac.source=1.8
+javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}


### PR DESCRIPTION
- Accomplished by modifying NetBeans project properties; changed "Source/Binary Format" option from "JDK 7" to "JDK 8"